### PR TITLE
Proposal: drop support for Java 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ matrix:
         - os: linux
           jdk: openjdk8
 
-        - os: linux
-          dist: trusty
-          jdk: openjdk7
-          install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!micrometer-metrics-listener'
-          script: mvn test -B -pl '!micrometer-metrics-listener'
-
         - os: osx
           osx_image: xcode8.3
           env: PUSHY_SSL_PROVIDER=jdk

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ If you don't use Maven (or something else that understands Maven dependencies, l
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
-Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-native 2.0.26.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
-
-Under Java 8 and newer, Pushy does not require a native SSL provider, but users may choose to use it regardless for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
+Pushy itself requires Java 8 or newer to build and run. While not required, users may choose to use [netty-native](http://netty.io/wiki/forked-tomcat-native.html) as an SSL provider for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
 
 ```xml
 <dependency>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -72,7 +72,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.21</jmh.version>
-        <javac.target>1.7</javac.target>
+        <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <!-- 3.5.1 is the last version supporting Java 7. -->
-                    <version>3.5.1</version>
+                    <version>4.2.1</version>
                 </plugin>
 
                 <plugin>
@@ -172,8 +171,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.7.0</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
 

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -145,20 +145,6 @@
 
     <profiles>
         <profile>
-            <id>jdk-7</id>
-            <activation>
-                <jdk>1.7</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
             <id>test-with-jdk-ssl-provider</id>
             <activation>
                 <property>


### PR DESCRIPTION
When we started the Pushy project seven years ago, we opted to target Java 7 as the minimum supported version of Java. Java 7 is no longer officially, publicly supported, and it'd be great to move on to at least Java 8 generally to stay up to date (though even Java 8 is pretty old at this point) and take advantage of new language features.

This pull request does the bare minimum we'd need to do to move to Java 8; if we adopt the move to Java 8, I'd expect to follow it up with pull requests to use JSR-310 date/time types, JUnit 5, `Optionals`, and lambdas where appropriate.

Still, I'd love to get feedback from the community. Do you still depend on Java 7? What would this change mean for you? If there's little to no demand for Java 7 support, we could make this change soon. Otherwise, I'll come up with a more detailed transition plan.

Thanks, everybody!