### PR TITLE
Untangle connection error handling

### DIFF
--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
@@ -248,8 +248,18 @@ public class ApnsClientTest extends AbstractClientServerTest {
             assertFalse("Clients must not connect to untrusted servers.",
                     sendFuture.isSuccess());
 
+            boolean hasSSLHandshakeException = false;
+            {
+                Throwable cause = sendFuture.cause();
+
+                while (!hasSSLHandshakeException && cause != null) {
+                    hasSSLHandshakeException = (cause instanceof SSLHandshakeException);
+                    cause = cause.getCause();
+                }
+            }
+
             assertTrue("Clients should refuse to connect to untrusted servers due to an SSL handshake failure.",
-                    sendFuture.cause() instanceof SSLHandshakeException);
+                    hasSSLHandshakeException);
         } finally {
             cautiousClient.close().await();
             server.shutdown().await();


### PR DESCRIPTION
Pushy's connection and handshaking process has changed a lot over the years as the protocol has evolved, as Pushy itself has become more advanced, and as I've learned new things. One consequence of all of that change is that establishing connections is generally getting more robust over time. Another is that we sometimes wind up with accumulated cruft that was mostly there to support old use cases and doesn't make sense any more.

This pull request eliminates some of the old cruft and, as a result, greatly simplifies the process of detecting, reporting, and handling errors that pop up when establishing new connections to an APNs server. The major changes:

1. We now build the entire pipeline up front rather than adding handlers in phases.
2. We've eliminated several "backstop" error-catching mechanisms.
3. As a consequence of the other changes, we're able to centralize exception handling in the `ApnsClientHandler`, which is the last handler in the pipeline.

@eugeneseppel I believe this fixes #693 by eliminating competition between error-reporting mechanisms.

This is a pretty significant change, so I'm going to save it for the next "major" release. Feedback is very, very welcome!

This whole thing is easier to read with [whitespace-only changes hidden](https://github.com/relayrides/pushy/pull/749/files?w=1).