### PR TITLE
Use lambdas and improved type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,24 +132,20 @@ try {
 Again, it's important to note that the returned `Future` supports listeners; waiting for each individual push notification is inefficient in practice, and most users will be better serverd by adding a listener to the `Future` instead of blocking until it completes. As an example:
 
 ```java
-sendNotificationFuture.addListener(new PushNotificationResponseListener<SimpleApnsPushNotification>() {
+sendNotificationFuture.addListener(future -> {
+    // When using a listener, callers should check for a failure to send a
+    // notification by checking whether the future itself was successful
+    // since an exception will not be thrown.
+    if (future.isSuccess()) {
+        final PushNotificationResponse<SimpleApnsPushNotification> pushNotificationResponse =
+                sendNotificationFuture.getNow();
 
-    @Override
-    public void operationComplete(final PushNotificationFuture<SimpleApnsPushNotification, PushNotificationResponse<SimpleApnsPushNotification>> future) throws Exception {
-        // When using a listener, callers should check for a failure to send a
-        // notification by checking whether the future itself was successful
-        // since an exception will not be thrown.
-        if (future.isSuccess()) {
-            final PushNotificationResponse<SimpleApnsPushNotification> pushNotificationResponse =
-                    sendNotificationFuture.getNow();
-
-            // Handle the push notification response as before from here.
-        } else {
-            // Something went wrong when trying to send the notification to the
-            // APNs gateway. We can find the exception that caused the failure
-            // by getting future.cause().
-            future.cause().printStackTrace();
-        }
+        // Handle the push notification response as before from here.
+    } else {
+        // Something went wrong when trying to send the notification to the
+        // APNs gateway. We can find the exception that caused the failure
+        // by getting future.cause().
+        future.cause().printStackTrace();
     }
 });
 ```

--- a/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
@@ -29,7 +29,6 @@ import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.openjdk.jmh.annotations.*;
 
@@ -124,13 +123,9 @@ public class ApnsClientBenchmark {
         final CountDownLatch countDownLatch = new CountDownLatch(this.pushNotifications.size());
 
         for (final SimpleApnsPushNotification notification : this.pushNotifications) {
-            this.client.sendNotification(notification).addListener(new GenericFutureListener<Future<PushNotificationResponse<SimpleApnsPushNotification>>>() {
-
-                @Override
-                public void operationComplete(final Future<PushNotificationResponse<SimpleApnsPushNotification>> future) {
-                    if (future.isSuccess()) {
-                        countDownLatch.countDown();
-                    }
+            this.client.sendNotification(notification).addListener(future -> {
+                if (future.isSuccess()) {
+                    countDownLatch.countDown();
                 }
             });
         }

--- a/dropwizard-metrics-listener/src/main/java/com/eatthepath/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
+++ b/dropwizard-metrics-listener/src/main/java/com/eatthepath/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
@@ -152,12 +152,8 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
         this.acceptedNotifications = this.metrics.meter(ACCEPTED_NOTIFICATIONS_METER_NAME);
         this.rejectedNotifications = this.metrics.meter(REJECTED_NOTIFICATIONS_METER_NAME);
 
-        this.metrics.register(OPEN_CONNECTIONS_GAUGE_NAME, new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return DropwizardApnsClientMetricsListener.this.openConnections.get();
-            }
-        });
+        this.metrics.register(OPEN_CONNECTIONS_GAUGE_NAME,
+                (Gauge<Integer>) DropwizardApnsClientMetricsListener.this.openConnections::get);
 
         this.connectionFailures = this.metrics.meter(CONNECTION_FAILURES_METER_NAME);
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */
+@SuppressWarnings("unused")
 public class ApnsClientBuilder {
     private InetSocketAddress apnsServerAddress;
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/P12Util.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/P12Util.java
@@ -60,7 +60,7 @@ class P12Util {
 
         try {
             keyStore.load(p12InputStream, password.toCharArray());
-        } catch (NoSuchAlgorithmException | CertificateException e) {
+        } catch (final NoSuchAlgorithmException | CertificateException e) {
             throw new KeyStoreException(e);
         }
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -110,12 +110,9 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
                 this.authenticationToken = new AuthenticationToken(signingKey, new Date());
                 this.mostRecentStreamWithNewToken = streamId;
 
-                this.expireTokenFuture = context.executor().schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        log.debug("Proactively expiring authentication token.");
-                        TokenAuthenticationApnsClientHandler.this.authenticationToken = null;
-                    }
+                this.expireTokenFuture = context.executor().schedule(() -> {
+                    log.debug("Proactively expiring authentication token.");
+                    TokenAuthenticationApnsClientHandler.this.authenticationToken = null;
                 }, tokenExpirationMillis, TimeUnit.MILLISECONDS);
             } catch (final NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
                 // This should never happen because we check the key/algorithm at signing key construction time.

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsSigningKey.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsSigningKey.java
@@ -161,7 +161,7 @@ public class ApnsSigningKey extends ApnsKey implements ECPrivateKey {
 
             try {
                 signingKey = (ECPrivateKey) keyFactory.generatePrivate(keySpec);
-            } catch (InvalidKeySpecException e) {
+            } catch (final InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
         }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsVerificationKey.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsVerificationKey.java
@@ -168,7 +168,7 @@ public class ApnsVerificationKey extends ApnsKey implements ECPublicKey {
 
             try {
                 verificationKey = (ECPublicKey) keyFactory.generatePublic(keySpec);
-            } catch (InvalidKeySpecException e) {
+            } catch (final InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
         }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/AcceptAllPushNotificationHandlerFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/AcceptAllPushNotificationHandlerFactory.java
@@ -22,9 +22,6 @@
 
 package com.eatthepath.pushy.apns.server;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http2.Http2Headers;
-
 import javax.net.ssl.SSLSession;
 
 /**
@@ -47,12 +44,8 @@ public class AcceptAllPushNotificationHandlerFactory implements PushNotification
      */
     @Override
     public PushNotificationHandler buildHandler(final SSLSession sslSession) {
-        return new PushNotificationHandler() {
-
-            @Override
-            public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) {
-                // Accept everything unconditionally!
-            }
+        return (headers, payload) -> {
+            // Accept everything unconditionally!
         };
     }
 }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/BaseHttp2ServerBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/BaseHttp2ServerBuilder.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
+@SuppressWarnings("UnusedReturnValue")
 abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
 
     protected X509Certificate[] certificateChain;
@@ -79,7 +80,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
+    public BaseHttp2ServerBuilder<T> setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
         this.certificateChain = null;
         this.privateKey = null;
 
@@ -109,7 +110,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
+    public BaseHttp2ServerBuilder<T> setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
         this.certificateChain = null;
         this.privateKey = null;
 
@@ -136,7 +137,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
+    public BaseHttp2ServerBuilder<T> setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
         this.certificateChain = certificates;
         this.privateKey = privateKey;
 
@@ -163,7 +164,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
+    public BaseHttp2ServerBuilder<T> setTrustedClientCertificateChain(final File certificatePemFile) {
         this.trustedClientCertificatePemFile = certificatePemFile;
         this.trustedClientCertificateInputStream = null;
         this.trustedClientCertificates = null;
@@ -183,7 +184,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
+    public BaseHttp2ServerBuilder<T> setTrustedClientCertificateChain(final InputStream certificateInputStream) {
         this.trustedClientCertificatePemFile = null;
         this.trustedClientCertificateInputStream = certificateInputStream;
         this.trustedClientCertificates = null;
@@ -203,7 +204,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
+    public BaseHttp2ServerBuilder<T> setTrustedServerCertificateChain(final X509Certificate... certificates) {
         this.trustedClientCertificatePemFile = null;
         this.trustedClientCertificateInputStream = null;
         this.trustedClientCertificates = certificates;
@@ -222,7 +223,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+    public BaseHttp2ServerBuilder<T> setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
         this.eventLoopGroup = eventLoopGroup;
         return this;
     }
@@ -238,7 +239,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.12
      */
-    public BaseHttp2ServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
+    public BaseHttp2ServerBuilder<T> setMaxConcurrentStreams(final int maxConcurrentStreams) {
         if (maxConcurrentStreams <= 0) {
             throw new IllegalArgumentException("Maximum number of concurrent streams must be positive.");
         }
@@ -268,7 +269,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.13.7
      */
-    public BaseHttp2ServerBuilder setUseAlpn(final boolean useAlpn) {
+    public BaseHttp2ServerBuilder<T> setUseAlpn(final boolean useAlpn) {
         this.useAlpn = useAlpn;
         return this;
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServer.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServer.java
@@ -67,7 +67,7 @@ public class MockApnsServer extends BaseHttp2Server {
     }
 
     @Override
-    protected void addHandlersToPipeline(final SSLSession sslSession, final ChannelPipeline pipeline) throws Exception {
+    protected void addHandlersToPipeline(final SSLSession sslSession, final ChannelPipeline pipeline) {
         final PushNotificationHandler pushNotificationHandler = this.handlerFactory.buildHandler(sslSession);
 
         final MockApnsServerHandler serverHandler = new MockApnsServerHandler.MockApnsServerHandlerBuilder()

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerHandler.java
@@ -138,7 +138,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         }
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private static class ErrorPayload {
         private final String reason;
         private final Date timestamp;
@@ -330,7 +330,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             final ChannelPromise dataPromise = context.newPromise();
             this.encoder().writeData(context, rejectNotificationResponse.getStreamId(), Unpooled.wrappedBuffer(payloadBytes), 0, true, dataPromise);
 
-            final PromiseCombiner promiseCombiner = new PromiseCombiner();
+            final PromiseCombiner promiseCombiner = new PromiseCombiner(context.executor());
             promiseCombiner.addAll((ChannelFuture) headersPromise, dataPromise);
             promiseCombiner.finish(writePromise);
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ServerChannelClassUtil.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ServerChannelClassUtil.java
@@ -49,7 +49,6 @@ class ServerChannelClassUtil {
      *
      * @throws IllegalArgumentException in case of null or unrecognized event loop group
      */
-    @SuppressWarnings("unchecked")
     static Class<? extends ServerChannel> getServerSocketChannelClass(final EventLoopGroup eventLoopGroup) {
         Objects.requireNonNull(eventLoopGroup);
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
@@ -100,7 +100,7 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
             if (!authenticationToken.verifySignature(verificationKey)) {
                 throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
             }
-        } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
+        } catch (final NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
             // This should never happen (here, at least) because we check keys at construction time. If something's
             // going to go wrong, it will go wrong before we ever get here.
             log.error("Failed to verify authentication token signature.", e);

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerFactory.java
@@ -72,16 +72,16 @@ public class ValidatingPushNotificationHandlerFactory implements PushNotificatio
      */
     public ValidatingPushNotificationHandlerFactory(final Map<String, Set<String>> deviceTokensByTopic, final Map<String, Date> expirationTimestampsByDeviceToken, final Map<String, ApnsVerificationKey> verificationKeysByKeyId, final Map<ApnsVerificationKey, Set<String>> topicsByVerificationKey) {
         this.deviceTokensByTopic = deviceTokensByTopic != null ?
-                deviceTokensByTopic : Collections.<String, Set<String>>emptyMap();
+                deviceTokensByTopic : Collections.emptyMap();
 
         this.expirationTimestampsByDeviceToken = expirationTimestampsByDeviceToken != null ?
-                expirationTimestampsByDeviceToken : Collections.<String, Date>emptyMap();
+                expirationTimestampsByDeviceToken : Collections.emptyMap();
 
         this.verificationKeysByKeyId = verificationKeysByKeyId != null ?
-                verificationKeysByKeyId : Collections.<String, ApnsVerificationKey>emptyMap();
+                verificationKeysByKeyId : Collections.emptyMap();
 
         this.topicsByVerificationKey = topicsByVerificationKey != null ?
-                topicsByVerificationKey : Collections.<ApnsVerificationKey, Set<String>>emptyMap();
+                topicsByVerificationKey : Collections.emptyMap();
     }
 
     @Override

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -35,6 +35,7 @@ import java.util.*;
  *
  * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">Generating a Remote Notification</a>
  */
+@SuppressWarnings({"UnusedReturnValue", "unused"})
 public class ApnsPayloadBuilder {
 
     private String alertBody = null;
@@ -106,6 +107,7 @@ public class ApnsPayloadBuilder {
 
     private static final Gson GSON = new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
 
+    @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private static class SoundForCriticalAlert {
         private final String name;
         private final int critical;

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -31,10 +31,7 @@ import com.eatthepath.pushy.apns.server.MockApnsServerListener;
 import com.eatthepath.pushy.apns.server.PushNotificationHandlerFactory;
 import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultPromise;
-import io.netty.util.concurrent.GlobalEventExecutor;
-import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.concurrent.*;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -99,7 +96,7 @@ public class AbstractClientServerTest {
 
     @AfterClass
     public static void tearDownAfterClass() throws Exception {
-        final PromiseCombiner combiner = new PromiseCombiner();
+        final PromiseCombiner combiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE);
         combiner.addAll(CLIENT_EVENT_LOOP_GROUP.shutdownGracefully(), SERVER_EVENT_LOOP_GROUP.shutdownGracefully());
 
         final Promise<Void> shutdownPromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsChannelPoolTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsChannelPoolTest.java
@@ -243,12 +243,9 @@ public class ApnsChannelPoolTest {
         final PooledObjectFactory<Channel> factory = new PooledObjectFactory<Channel>() {
             @Override
             public Future<Channel> create(final Promise<Channel> promise) {
-                EVENT_EXECUTOR.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        promise.trySuccess(new TestChannel(true));
-                        createSuccess.setSuccess(null);
-                    }
+                EVENT_EXECUTOR.schedule(() -> {
+                    promise.trySuccess(new TestChannel(true));
+                    createSuccess.setSuccess(null);
                 }, 1, TimeUnit.SECONDS);
                 return promise;
             }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientBuilderTest.java
@@ -45,7 +45,7 @@ public class ApnsClientBuilderTest {
     private static NioEventLoopGroup EVENT_LOOP_GROUP;
 
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    public static void setUpBeforeClass() {
         EVENT_LOOP_GROUP = new NioEventLoopGroup(1);
     }
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ExampleApp.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ExampleApp.java
@@ -28,7 +28,6 @@ import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.eatthepath.pushy.apns.util.TokenUtil;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
-import com.eatthepath.pushy.apns.util.concurrent.PushNotificationResponseListener;
 import io.netty.util.concurrent.Future;
 
 import java.io.File;
@@ -123,23 +122,20 @@ public class ExampleApp {
         // To send push notifications efficiently, it's best to attach listeners
         // to "send push notification" futures so we don't have to wait for the
         // server to reply before we start sending the next notification.
-        sendNotificationFuture.addListener(new PushNotificationResponseListener<SimpleApnsPushNotification>() {
-            @Override
-            public void operationComplete(final PushNotificationFuture<SimpleApnsPushNotification, PushNotificationResponse<SimpleApnsPushNotification>> future) throws Exception {
-                // When using a listener, callers should check for a failure to send a
-                // notification by checking whether the future itself was successful
-                // since an exception will not be thrown.
-                if (future.isSuccess()) {
-                    final PushNotificationResponse<SimpleApnsPushNotification> pushNotificationResponse =
-                            sendNotificationFuture.getNow();
+        sendNotificationFuture.addListener(future -> {
+            // When using a listener, callers should check for a failure to send a
+            // notification by checking whether the future itself was successful
+            // since an exception will not be thrown.
+            if (future.isSuccess()) {
+                final PushNotificationResponse<SimpleApnsPushNotification> pushNotificationResponse =
+                        sendNotificationFuture.getNow();
 
-                    // Handle the push notification response as before from here.
-                } else {
-                    // Something went wrong when trying to send the notification to the
-                    // APNs gateway. We can find the exception that caused the failure
-                    // by getting future.cause().
-                    future.cause().printStackTrace();
-                }
+                // Handle the push notification response as before from here.
+            } else {
+                // Something went wrong when trying to send the notification to the
+                // APNs gateway. We can find the exception that caused the failure
+                // by getting future.cause().
+                future.cause().printStackTrace();
             }
         });
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/PrintTestNameRunListener.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/PrintTestNameRunListener.java
@@ -35,7 +35,7 @@ import org.junit.runner.notification.RunListener;
 public class PrintTestNameRunListener extends RunListener {
 
     @Override
-    public void testStarted(final Description description) throws Exception {
+    public void testStarted(final Description description) {
         System.out.println("\t" + description.getMethodName());
     }
 }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/MockApnsServerTest.java
@@ -24,13 +24,10 @@ package com.eatthepath.pushy.apns.server;
 
 import com.eatthepath.pushy.apns.*;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.concurrent.Future;
 import org.junit.Test;
 
-import javax.net.ssl.SSLSession;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -191,20 +188,9 @@ public class MockApnsServerTest extends AbstractClientServerTest {
     public void testListenerRejectedNotification() throws Exception {
         final TestMockApnsServerListener listener = new TestMockApnsServerListener();
 
-        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
-
-            @Override
-            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
-                return new PushNotificationHandler() {
-
-                    @Override
-                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-                        throw new RejectedNotificationException(RejectionReason.BAD_DEVICE_TOKEN);
-                    }
-                };
-            }
+        final MockApnsServer server = this.buildServer(sslSession -> (headers, payload) -> {
+            throw new RejectedNotificationException(RejectionReason.BAD_DEVICE_TOKEN);
         }, listener);
-
 
         final ApnsClient client = this.buildTokenAuthenticationClient();
 
@@ -233,17 +219,8 @@ public class MockApnsServerTest extends AbstractClientServerTest {
         final TestMockApnsServerListener listener = new TestMockApnsServerListener();
         final Date expiration = new Date();
 
-        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
-            @Override
-            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
-                return new PushNotificationHandler() {
-
-                    @Override
-                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-                        throw new UnregisteredDeviceTokenException(expiration);
-                    }
-                };
-            }
+        final MockApnsServer server = this.buildServer(sslSession -> (headers, payload) -> {
+            throw new UnregisteredDeviceTokenException(expiration);
         }, listener);
 
         final ApnsClient client = this.buildTokenAuthenticationClient();
@@ -272,18 +249,8 @@ public class MockApnsServerTest extends AbstractClientServerTest {
     public void testListenerInternalServerError() throws Exception {
         final TestMockApnsServerListener listener = new TestMockApnsServerListener();
 
-        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
-
-            @Override
-            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
-                return new PushNotificationHandler() {
-
-                    @Override
-                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) {
-                        throw new RuntimeException("Everything is terrible.");
-                    }
-                };
-            }
+        final MockApnsServer server = this.buildServer(sslSession -> (headers, payload) -> {
+            throw new RuntimeException("Everything is terrible.");
         }, listener);
 
         final ApnsClient client = this.buildTokenAuthenticationClient();
@@ -346,18 +313,8 @@ public class MockApnsServerTest extends AbstractClientServerTest {
 
     @Test
     public void testApnsIdForRejectedNotification() throws Exception {
-        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
-
-            @Override
-            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
-                return new PushNotificationHandler() {
-
-                    @Override
-                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-                        throw new RejectedNotificationException(RejectionReason.MISSING_TOPIC);
-                    }
-                };
-            }
+        final MockApnsServer server = this.buildServer(sslSession -> (headers, payload) -> {
+            throw new RejectedNotificationException(RejectionReason.MISSING_TOPIC);
         });
 
         final ApnsClient client = this.buildTokenAuthenticationClient();

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandlerTest.java
@@ -83,7 +83,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.remove(APNS_AUTHORIZATION_HEADER);
 
         this.testWithExpectedRejection("Push notifications without an authentication token should be rejected",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.MISSING_PROVIDER_TOKEN);
@@ -94,7 +94,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.set(APNS_AUTHORIZATION_HEADER, "bearer");
 
         this.testWithExpectedRejection("Push notifications without an authentication token should be rejected",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.MISSING_PROVIDER_TOKEN);
@@ -105,7 +105,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.set(APNS_AUTHORIZATION_HEADER, "Definitely not a legit authorization header.");
 
         this.testWithExpectedRejection("Push notifications without an authentication token should be rejected",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.MISSING_PROVIDER_TOKEN);
@@ -116,7 +116,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.set(APNS_AUTHORIZATION_HEADER, "bearer Definitely not a legit token.");
 
         this.testWithExpectedRejection("Push notifications without an authentication token should be rejected",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.INVALID_PROVIDER_TOKEN);
@@ -137,7 +137,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
 
         final TokenAuthenticationValidatingPushNotificationHandler handler =
                 new TokenAuthenticationValidatingPushNotificationHandler(
-                        DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap(), verificationKeysByKeyId, topicsByVerificationKey);
+                        DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap(), verificationKeysByKeyId, topicsByVerificationKey);
 
         final AuthenticationToken authenticationToken = new AuthenticationToken(signingKey, new Date());
 
@@ -160,7 +160,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.set(APNS_AUTHORIZATION_HEADER, unverifiedToken.getAuthorizationHeader());
 
         this.testWithExpectedRejection("Push notifications with an authentication token that can't be verified by the registered public key should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.INVALID_PROVIDER_TOKEN);
@@ -173,7 +173,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
         this.headers.set(APNS_AUTHORIZATION_HEADER, expiredToken.getAuthorizationHeader());
 
         this.testWithExpectedRejection("Push notifications with an expired authentication token should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.EXPIRED_PROVIDER_TOKEN);
@@ -188,7 +188,7 @@ public class TokenAuthenticationValidatingPushNotificationHandlerTest extends Va
 
         final TokenAuthenticationValidatingPushNotificationHandler handler =
                 new TokenAuthenticationValidatingPushNotificationHandler(
-                        DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap(), verificationKeysByKeyId, topicsByVerificationKey);
+                        DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap(), verificationKeysByKeyId, topicsByVerificationKey);
 
         final AuthenticationToken authenticationToken = new AuthenticationToken(signingKey, new Date());
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -58,6 +58,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
     protected Http2Headers headers;
     protected ByteBuf payload;
 
+    @SuppressWarnings("SameParameterValue")
     protected abstract ValidatingPushNotificationHandler getHandler(final Map<String, Set<String>> deviceTokensByTopic, final Map<String, Date> expirationTimestampsByDeviceToken);
 
     protected abstract void addAcceptableCredentialsToHeaders(Http2Headers headers) throws Exception;
@@ -84,7 +85,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
     @Test
     public void testHandleNotificationWithValidNotification() throws Exception {
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
     }
 
@@ -93,7 +94,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.set(APNS_ID_HEADER, "This is not a valid UUID.");
 
         this.testWithExpectedRejection("Push notifications with an invalid APNs ID should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.BAD_MESSAGE_ID);
@@ -103,7 +104,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
     public void testHandleNotificationWithCollapseId() throws Exception {
         this.headers.set(APNS_COLLAPSE_ID_HEADER, "Collapse ID!");
 
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
     }
 
@@ -112,7 +113,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.set(APNS_COLLAPSE_ID_HEADER, "1234567890123456789012345678901234567890123456789012345678901234567890");
 
         this.testWithExpectedRejection("Push notifications with a collapse ID longer than 64 bytes should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.BAD_COLLAPSE_ID);
@@ -122,7 +123,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
     public void testHandleNotificationWithExpirationDate() throws Exception {
         this.headers.setInt(APNS_EXPIRATION_HEADER, (int) (new Date().getTime() / 1000));
 
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
     }
 
@@ -131,7 +132,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.remove(APNS_TOPIC_HEADER);
 
         this.testWithExpectedRejection("Push notifications without a topic should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.MISSING_TOPIC);
@@ -141,12 +142,12 @@ public abstract class ValidatingPushNotificationHandlerTest {
     public void testHandleNotificationWithSpecifiedPriority() throws Exception {
         this.headers.setInt(APNS_PRIORITY_HEADER, DeliveryPriority.CONSERVE_POWER.getCode());
 
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
 
         this.headers.setInt(APNS_PRIORITY_HEADER, DeliveryPriority.IMMEDIATE.getCode());
 
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
     }
 
@@ -155,7 +156,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.setInt(APNS_PRIORITY_HEADER, 9000);
 
         this.testWithExpectedRejection("Push notifications without an unrecognized priority should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.BAD_PRIORITY);
@@ -166,7 +167,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.path("/example/definitely-not-the-correct-path/");
 
         this.testWithExpectedRejection("Push notifications with a bad path should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.BAD_PATH);
@@ -177,7 +178,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.path(APNS_PATH_PREFIX);
 
         this.testWithExpectedRejection("Push notifications with no device token should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.MISSING_DEVICE_TOKEN);
@@ -188,7 +189,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.path(APNS_PATH_PREFIX + "Definitely not a legit device token.");
 
         this.testWithExpectedRejection("Push notifications with a malformed device token should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.BAD_DEVICE_TOKEN);
@@ -211,7 +212,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
         this.headers.set(APNS_TOPIC_HEADER, TOPIC + ".definitely.wrong");
 
         this.testWithExpectedRejection("Push notifications with a device token for the wrong topic should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 this.payload,
                 RejectionReason.DEVICE_TOKEN_NOT_FOR_TOPIC);
@@ -220,7 +221,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
     @Test
     public void testHandleNotificationWithMissingPayload() {
         this.testWithExpectedRejection("Push notifications with a device token for the wrong topic should be rejected.",
-                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                 this.headers,
                 null,
                 RejectionReason.PAYLOAD_EMPTY);
@@ -232,7 +233,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
         try {
             this.testWithExpectedRejection("Push notifications with a device token for the wrong topic should be rejected.",
-                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                     this.headers,
                     emptyPayload,
                     RejectionReason.PAYLOAD_EMPTY);
@@ -253,7 +254,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
             largePayload.writeBytes(payloadBytes);
 
             this.testWithExpectedRejection("Push notifications with a device token for the wrong topic should be rejected.",
-                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap()),
+                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
                     this.headers,
                     largePayload,
                     RejectionReason.PAYLOAD_TOO_LARGE);


### PR DESCRIPTION
As a follow-up to #746, we can now take advantage of lambdas and Java 8's improved type inference to reduce verbosity throughout the project.

The important parts of this pull request are much easier to identify with [whitespace-only changes hidden](https://github.com/jchambers/pushy/pull/755/files?w=1).