### PR TITLE
Update to Netty 4.1.48

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/jchambers/pushy/releases/download/pushy-0.13.11/pushy-0.13.11.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.46](http://netty.io/)
+- [netty 4.1.48](http://netty.io/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.46.Final</netty.version>
+        <netty.version>4.1.48.Final</netty.version>
         <junit.version>5.6.0</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This updates everything to the latest version of Netty. Although there are some important fixes in Netty 4.1.47 and 4.1.48, I don't believe any of them affect Pushy directly.