### PR TITLE
Check for null streams before attaching a "cause" property

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -473,7 +473,11 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     @Override
     protected void onStreamError(final ChannelHandlerContext context, final boolean isOutbound, final Throwable cause, final Http2Exception.StreamException streamException) {
         final Http2Stream stream = this.connection().stream(streamException.streamId());
-        stream.setProperty(this.streamErrorCausePropertyKey, streamException);
+
+        // The affected stream may already be closed (or was never open in the first place)
+        if (stream != null) {
+            stream.setProperty(this.streamErrorCausePropertyKey, streamException);
+        }
 
         super.onStreamError(context, isOutbound, cause, streamException);
     }


### PR DESCRIPTION
This fixes an issue where we were unconditionally attempting to attach a property to a `Stream`, even though that stream might be null. This fixes #767.

Thanks, @dbakr!