### PR TITLE
Release reference-counted SSL contexts in a `finally` block

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
@@ -201,11 +201,13 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
 
     @Override
     public void close() {
-        this.addressResolverGroup.close();
-
-        if (this.sslContext instanceof ReferenceCounted) {
-            if (this.hasReleasedSslContext.compareAndSet(false, true)) {
-                ((ReferenceCounted) this.sslContext).release();
+        try {
+            this.addressResolverGroup.close();
+        } finally {
+            if (this.sslContext instanceof ReferenceCounted) {
+                if (this.hasReleasedSslContext.compareAndSet(false, true)) {
+                    ((ReferenceCounted) this.sslContext).release();
+                }
             }
         }
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -560,15 +560,15 @@ public class ApnsClientBuilder {
             sslContext = sslContextBuilder.build();
         }
 
-        final ApnsClient client = new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
-                this.tokenExpiration, this.proxyHandlerFactory, this.connectionTimeout,
-                this.idlePingInterval, this.gracefulShutdownTimeout, this.concurrentConnections,
-                this.metricsListener, this.frameLogger, this.eventLoopGroup);
-
-        if (sslContext instanceof ReferenceCounted) {
-            ((ReferenceCounted) sslContext).release();
+        try {
+            return new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
+                    this.tokenExpiration, this.proxyHandlerFactory, this.connectionTimeout,
+                    this.idlePingInterval, this.gracefulShutdownTimeout, this.concurrentConnections,
+                    this.metricsListener, this.frameLogger, this.eventLoopGroup);
+        } finally {
+            if (sslContext instanceof ReferenceCounted) {
+                ((ReferenceCounted) sslContext).release();
+            }
         }
-
-        return client;
     }
 }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/BaseHttp2ServerBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/BaseHttp2ServerBuilder.java
@@ -331,13 +331,13 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
             sslContext = sslContextBuilder.build();
         }
 
-        final T server = this.constructServer(sslContext);
-
-        if (sslContext instanceof ReferenceCounted) {
-            ((ReferenceCounted) sslContext).release();
+        try {
+            return this.constructServer(sslContext);
+        } finally {
+            if (sslContext instanceof ReferenceCounted) {
+                ((ReferenceCounted) sslContext).release();
+            }
         }
-
-        return server;
     }
 
     protected abstract T constructServer(final SslContext sslContext);


### PR DESCRIPTION
While it's still not clear to me how #768 could be happening, this pull request eliminates a couple of possibilities (though I think it's unlikely they're the cause).

In the absence of more information, I think this closes #768 for now.