### PR TITLE
Add GSON/Jackson payload builders as sub-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Pushy's APNs clients maintain an internal pool of connections to the APNs server
 final SimpleApnsPushNotification pushNotification;
 
 {
-    final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
+    final ApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder();
     payloadBuilder.setAlertBody("Example!");
 
     final String payload = payloadBuilder.build();

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ final SimpleApnsPushNotification pushNotification;
 }
 ```
 
+Pushy includes a [`SimpleApnsPayloadBuilder`](https://pushy-apns.org/apidocs/0.14/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilder.html), and payload builders based on [Gson](https://github.com/jchambers/pushy/tree/master/gson-payload-builder) and [Jackson](https://github.com/jchambers/pushy/tree/master/jackson-payload-builder) are available as separate modules. [APNs payloads are just JSON strings](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification), and callers may produce payloads by the method of their choice; while Pushy's payload builders may be convenient, callers are _not_ obligated to use them.
+
 The process of sending a push notification is asynchronous; although the process of sending a notification and getting a reply from the server may take some time, the client will return a [`CompletableFuture`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html) right away. You can use that `CompletableFuture` to track the progress and eventual outcome of the sending operation. Note that sending a notification returns a [`PushNotificationFuture`](https://pushy-apns.org/apidocs/0.13/com/eatthepath/pushy/apns/util/concurrent/PushNotificationFuture.html), which is a subclass of `CompletableFuture` that always holds a reference to the notification that was sent.
 
 ```java

--- a/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
@@ -26,6 +26,7 @@ import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
 import com.eatthepath.pushy.apns.server.BenchmarkApnsServer;
 import com.eatthepath.pushy.apns.server.BenchmarkApnsServerBuilder;
 import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.Future;
@@ -101,7 +102,7 @@ public class ApnsClientBenchmark {
 
         this.pushNotifications = new ArrayList<>(this.notificationCount);
         {
-            final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
+            final ApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder();
 
             for (int i = 0; i < this.notificationCount; i++) {
                 final String payload =

--- a/benchmark/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilderBenchmark.java
+++ b/benchmark/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilderBenchmark.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 @State(Scope.Thread)
-public class ApnsPayloadBuilderBenchmark {
+public class SimpleApnsPayloadBuilderBenchmark {
 
-    private ApnsPayloadBuilder apnsPayloadBuilder;
+    private SimpleApnsPayloadBuilder payloadBuilder;
 
     @Param({"512", "4096"})
     public int messageBodyLength;
@@ -43,7 +43,7 @@ public class ApnsPayloadBuilderBenchmark {
 
     @Setup
     public void setUp() {
-        this.apnsPayloadBuilder = new ApnsPayloadBuilder();
+        this.payloadBuilder = new SimpleApnsPayloadBuilder();
 
         final char[] messageBodyCharacters;
         {
@@ -68,7 +68,7 @@ public class ApnsPayloadBuilderBenchmark {
 
     @Benchmark
     public String testBuild() {
-        this.apnsPayloadBuilder.setAlertBody(this.messageBody);
-        return this.apnsPayloadBuilder.build();
+        this.payloadBuilder.setAlertBody(this.messageBody);
+        return this.payloadBuilder.build();
     }
 }

--- a/gson-payload-builder/README.md
+++ b/gson-payload-builder/README.md
@@ -1,0 +1,40 @@
+# Gson APNs payload builder for Pushy
+
+This module provides an [`ApnsPayloadBuilder`](https://pushy-apns.org/apidocs/0.14/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.html) that uses [Gson](https://github.com/google/gson) to serialize APNs payloads. If you use [Maven](http://maven.apache.org/), you can add the payload builder to your project by adding the following dependency declaration to your POM:
+
+```xml
+<dependency>
+    <groupId>com.eatthepath</groupId>
+    <artifactId>pushy-gson-payload-builder</artifactId>
+    <version>0.14.0</version>
+</dependency>
+```
+
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Gson payload builder for Pushy depends on Pushy itself (obviously enough) and version 2.8.6 of the [Gson library](https://github.com/google/gson).
+
+## Using the Gson payload builder
+
+Callers can construct a payload builder that uses a default Gson instance with `GsonPayloadBuilder`'s no-argument constructor:
+
+```java
+final ApnsPayloadBuilder gsonPayloadBuilder =
+        new GsonApnsPayloadBuilder();
+
+gsonPayloadBuilder.setAlertBody("Hello from GSON!");
+
+final String payload = gsonPayloadBuilder.build();
+```
+
+Callers can also provide their own Gson instance to customize how it serializes payloads:
+
+```java
+final ApnsPayloadBuilder gsonPayloadBuilder =
+        new GsonApnsPayloadBuilder(new GsonBuilder()
+                .disableHtmlEscaping()
+                .setDateFormat(DateFormat.SHORT, DateFormat.MEDIUM)
+                .create());
+```
+
+## License
+
+The Gson payload builder for Pushy is available under the [MIT License](http://opensource.org/licenses/MIT).

--- a/gson-payload-builder/pom.xml
+++ b/gson-payload-builder/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 Jon Chambers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pushy-gson-payload-builder</artifactId>
+    <version>0.13.12-SNAPSHOT</version>
+    <name>Gson APNs payload builder for Pushy</name>
+    <description>A payload builder for Pushy that uses Gson to serialize payloads.</description>
+
+    <parent>
+        <artifactId>pushy-parent</artifactId>
+        <groupId>com.eatthepath</groupId>
+        <version>0.13.12-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pushy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pushy</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <overview>${basedir}/src/main/java/overview.html</overview>
+                    <show>public</show>
+                    <links>
+                        <link>https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/</link>
+                        <link>https://pushy-apns.org/apidocs/0.14/</link>
+                    </links>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/gson/GsonApnsPayloadBuilder.java
+++ b/gson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/gson/GsonApnsPayloadBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.util.gson;
+
+import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.Objects;
+
+/**
+ * An APNs payload builder that serializes payloads with a {@link Gson} instance. Callers may provide their own
+ * {@code Gson} instance to change how the payload builder serializes custom properties.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.14.0
+ */
+public class GsonApnsPayloadBuilder extends ApnsPayloadBuilder {
+
+    private final Gson gson;
+
+    private static final Gson DEFAULT_GSON = new GsonBuilder()
+            .disableHtmlEscaping()
+            .serializeNulls()
+            .create();
+
+    /**
+     * Constructs a new payload builder with a default {@link Gson} instance.
+     */
+    public GsonApnsPayloadBuilder() {
+        this(DEFAULT_GSON);
+    }
+
+    /**
+     * Constructs a new payload builder with the given {@code Gson} instance.
+     *
+     * @param gson the {@code Gson} instance with which to serialize APNs payloads
+     */
+    public GsonApnsPayloadBuilder(final Gson gson) {
+        this.gson = Objects.requireNonNull(gson);
+    }
+
+    /**
+     * Returns a JSON representation of the push notification payload under construction.
+     *
+     * @return a JSON representation of the payload under construction
+     *
+     * @see #buildPayloadMap()
+     *
+     * @since 0.14.0
+     */
+    @Override
+    public String build() {
+        return this.gson.toJson(this.buildPayloadMap());
+    }
+
+    /**
+     * Returns a JSON representation of a
+     * <a href="https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/1-Introduction/Introduction.html#//apple_ref/doc/uid/TP40017387-CH1-SW1">Mobile
+     * Device Management</a> "wake up" payload.
+     *
+     * @param pushMagicValue the "push magic" string that the device sends to the MDM server in a {@code TokenUpdate}
+     * message
+     *
+     * @return a JSON representation of an MDM "wake up" notification payload
+     *
+     * @see <a href="https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/3-MDM_Protocol/MDM_Protocol.html#//apple_ref/doc/uid/TP40017387-CH3-SW2">Mobile
+     * Device Management (MDM) Protocol</a>
+     *
+     * @since 0.14.0
+     *
+     * @see #buildMdmPayloadMap(String)
+     */
+    @Override
+    public String buildMdmPayload(final String pushMagicValue) {
+        return this.gson.toJson(this.buildMdmPayloadMap(pushMagicValue));
+    }
+}

--- a/gson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/gson/package-info.java
+++ b/gson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/gson/package-info.java
@@ -20,26 +20,10 @@
  * THE SOFTWARE.
  */
 
-package com.eatthepath.pushy.apns.util;
-
-import com.eatthepath.json.JsonSerializer;
-
 /**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
+ * <p>Provides a concrete implementation of the {@link com.eatthepath.pushy.apns.util.ApnsPayloadBuilder} base class
+ * that serializes payloads using <a href="https://github.com/google/gson">Gson</a>.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
  */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
-
-    @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
-    }
-
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
-    }
-}
+package com.eatthepath.pushy.apns.util.gson;

--- a/gson-payload-builder/src/main/java/overview.html
+++ b/gson-payload-builder/src/main/java/overview.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright (c) 2020 Jon Chambers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Gson APNs Payload Builder for Pushy overview</title>
+</head>
+
+<body>
+<p>This library provides an APNs payload builder for
+    <a href="https://pushy-apns.org/" target="_top">Pushy</a> (a Java library for sending APNs push)
+    notifications that serializes payloads using
+    <a href="https://github.com/google/gson">Gson</a>.</p>
+
+<p>It is available under the <a href="http://opensource.org/licenses/MIT">MIT License</a>.</p>
+</body>
+</html>

--- a/gson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/ExampleApp.java
+++ b/gson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/ExampleApp.java
@@ -22,24 +22,25 @@
 
 package com.eatthepath.pushy.apns.util;
 
-import com.eatthepath.json.JsonSerializer;
+import com.eatthepath.pushy.apns.util.gson.GsonApnsPayloadBuilder;
+import com.google.gson.GsonBuilder;
 
-/**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
- *
- * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
- */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
+import java.text.DateFormat;
 
-    @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
-    }
+public class ExampleApp {
 
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
+    public static void main(final String... args) {
+        final ApnsPayloadBuilder gsonPayloadBuilder =
+                new GsonApnsPayloadBuilder();
+
+        gsonPayloadBuilder.setAlertBody("Hello from GSON!");
+
+        final String payload = gsonPayloadBuilder.build();
+
+        final ApnsPayloadBuilder customizedGsonPayloadBuilder =
+                new GsonApnsPayloadBuilder(new GsonBuilder()
+                        .disableHtmlEscaping()
+                        .setDateFormat(DateFormat.SHORT, DateFormat.MEDIUM)
+                        .create());
     }
 }

--- a/gson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/GsonApnsPayloadBuilderTest.java
+++ b/gson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/GsonApnsPayloadBuilderTest.java
@@ -22,24 +22,20 @@
 
 package com.eatthepath.pushy.apns.util;
 
-import com.eatthepath.json.JsonSerializer;
+import com.eatthepath.pushy.apns.util.gson.GsonApnsPayloadBuilder;
+import org.junit.jupiter.api.Test;
 
-/**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
- *
- * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
- */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GsonApnsPayloadBuilderTest extends ApnsPayloadBuilderTest {
 
     @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
+    protected ApnsPayloadBuilder getBuilder() {
+        return new GsonApnsPayloadBuilder();
     }
 
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
+    @Test
+    void gsonApnsPayloadBuilder() {
+        assertThrows(NullPointerException.class, () -> new GsonApnsPayloadBuilder(null));
     }
 }

--- a/jackson-payload-builder/README.md
+++ b/jackson-payload-builder/README.md
@@ -1,0 +1,40 @@
+# Jackson APNs payload builder for Pushy
+
+This module provides an [`ApnsPayloadBuilder`](https://pushy-apns.org/apidocs/0.14/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.html) that uses [Jackson](https://github.com/FasterXML/jackson) to serialize APNs payloads. If you use [Maven](http://maven.apache.org/), you can add the payload builder to your project by adding the following dependency declaration to your POM:
+
+```xml
+<dependency>
+    <groupId>com.eatthepath</groupId>
+    <artifactId>pushy-jackson-payload-builder</artifactId>
+    <version>0.14.0</version>
+</dependency>
+```
+
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Jackson payload builder for Pushy depends on Pushy itself (obviously enough) and version 2.10 of the [Jackson databind library](https://github.com/FasterXML/jackson-databind).
+
+## Using the Jackson payload builder
+
+Callers can construct a payload builder that uses a default Jackson object mapper with `JacksonPayloadBuilder`'s no-argument constructor:
+
+```java
+final ApnsPayloadBuilder jacksonPayloadBuilder =
+        new JacksonApnsPayloadBuilder();
+
+jacksonPayloadBuilder.setAlertBody("Hello from Jackson!");
+
+final String payload = jacksonPayloadBuilder.build();
+```
+
+Callers can also provide their own object mapper to customize how it serializes payloads:
+
+```java
+final ObjectMapper objectMapper = new ObjectMapper();
+objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+
+final ApnsPayloadBuilder customizedJacksonPayloadBuilder =
+        new JacksonApnsPayloadBuilder(objectMapper);
+```
+
+## License
+
+The Jackson payload builder for Pushy is available under the [MIT License](http://opensource.org/licenses/MIT).

--- a/jackson-payload-builder/pom.xml
+++ b/jackson-payload-builder/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 Jon Chambers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pushy-jackson-payload-builder</artifactId>
+    <version>0.13.12-SNAPSHOT</version>
+    <name>Jackson APNs payload builder for Pushy</name>
+    <description>A payload builder for Pushy that uses Jackson to serialize payloads.</description>
+
+    <parent>
+        <artifactId>pushy-parent</artifactId>
+        <groupId>com.eatthepath</groupId>
+        <version>0.13.12-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pushy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pushy</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <overview>${basedir}/src/main/java/overview.html</overview>
+                    <show>public</show>
+                    <links>
+                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.10/</link>
+                        <link>https://pushy-apns.org/apidocs/0.14/</link>
+                    </links>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jackson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/jackson/JacksonApnsPayloadBuilder.java
+++ b/jackson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/jackson/JacksonApnsPayloadBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.util.jackson;
+
+import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+
+/**
+ * An APNs payload builder that serializes payloads with an {@link ObjectMapper}. Callers may provide their own object
+ * mapper to change how the payload builder serializes custom properties.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.14.0
+ */
+public class JacksonApnsPayloadBuilder extends ApnsPayloadBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * Constructs a new payload builder with a default object mapper.
+     */
+    public JacksonApnsPayloadBuilder() {
+        this(DEFAULT_OBJECT_MAPPER);
+    }
+
+    /**
+     * Constructs a new payload builder with the given object mapper.
+     *
+     * @param objectMapper the object mapper with which to serialize APNs payloads
+     */
+    public JacksonApnsPayloadBuilder(final ObjectMapper objectMapper) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+    }
+
+    /**
+     * Returns a JSON representation of the push notification payload under construction.
+     *
+     * @return a JSON representation of the payload under construction
+     *
+     * @see #buildPayloadMap()
+     *
+     * @since 0.14.0
+     */
+    @Override
+    public String build() {
+        try {
+            return this.objectMapper.writeValueAsString(this.buildPayloadMap());
+        } catch (final JsonProcessingException e) {
+            // Reading through the ObjectMapper source, it appears that this can never actually happen when going
+            // straight to a string even though it's declared as a checked exception.
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns a JSON representation of a
+     * <a href="https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/1-Introduction/Introduction.html#//apple_ref/doc/uid/TP40017387-CH1-SW1">Mobile
+     * Device Management</a> "wake up" payload.
+     *
+     * @param pushMagicValue the "push magic" string that the device sends to the MDM server in a {@code TokenUpdate}
+     * message
+     *
+     * @return a JSON representation of an MDM "wake up" notification payload
+     *
+     * @see <a href="https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/3-MDM_Protocol/MDM_Protocol.html#//apple_ref/doc/uid/TP40017387-CH3-SW2">Mobile
+     * Device Management (MDM) Protocol</a>
+     *
+     * @since 0.14.0
+     *
+     * @see #buildMdmPayloadMap(String)
+     */
+    @Override
+    public String buildMdmPayload(final String pushMagicValue) {
+        try {
+            return this.objectMapper.writeValueAsString(this.buildMdmPayloadMap(pushMagicValue));
+        } catch (final JsonProcessingException e) {
+            // Reading through the ObjectMapper source, it appears that this can never actually happen when going
+            // straight to a string even though it's declared as a checked exception.
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/jackson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/jackson/package-info.java
+++ b/jackson-payload-builder/src/main/java/com/eatthepath/pushy/apns/util/jackson/package-info.java
@@ -20,26 +20,10 @@
  * THE SOFTWARE.
  */
 
-package com.eatthepath.pushy.apns.util;
-
-import com.eatthepath.json.JsonSerializer;
-
 /**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
+ * <p>Provides a concrete implementation of the {@link com.eatthepath.pushy.apns.util.ApnsPayloadBuilder} base class
+ * that serializes payloads using <a href="https://github.com/FasterXML/jackson">Jackson</a>.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
  */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
-
-    @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
-    }
-
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
-    }
-}
+package com.eatthepath.pushy.apns.util.jackson;

--- a/jackson-payload-builder/src/main/java/overview.html
+++ b/jackson-payload-builder/src/main/java/overview.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright (c) 2020 Jon Chambers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Jackson APNs Payload Builder for Pushy overview</title>
+</head>
+
+<body>
+<p>This library provides an APNs payload builder for
+    <a href="https://pushy-apns.org/" target="_top">Pushy</a> (a Java library for sending APNs push)
+    notifications that serializes payloads using
+    <a href="https://github.com/FasterXML/jackson">Jackson</a>.</p>
+
+<p>It is available under the <a href="http://opensource.org/licenses/MIT">MIT License</a>.</p>
+</body>
+</html>

--- a/jackson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/ExampleApp.java
+++ b/jackson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/ExampleApp.java
@@ -22,24 +22,24 @@
 
 package com.eatthepath.pushy.apns.util;
 
-import com.eatthepath.json.JsonSerializer;
+import com.eatthepath.pushy.apns.util.jackson.JacksonApnsPayloadBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
-/**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
- *
- * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
- */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
+public class ExampleApp {
 
-    @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
-    }
+    public static void main(final String... args) {
+        final ApnsPayloadBuilder jacksonPayloadBuilder =
+                new JacksonApnsPayloadBuilder();
 
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
+        jacksonPayloadBuilder.setAlertBody("Hello from Jackson!");
+
+        final String payload = jacksonPayloadBuilder.build();
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+
+        final ApnsPayloadBuilder customizedJacksonPayloadBuilder =
+                new JacksonApnsPayloadBuilder(objectMapper);
     }
 }

--- a/jackson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/JacksonApnsPayloadBuilderTest.java
+++ b/jackson-payload-builder/src/test/java/com/eatthepath/pushy/apns/util/JacksonApnsPayloadBuilderTest.java
@@ -22,24 +22,20 @@
 
 package com.eatthepath.pushy.apns.util;
 
-import com.eatthepath.json.JsonSerializer;
+import com.eatthepath.pushy.apns.util.jackson.JacksonApnsPayloadBuilder;
+import org.junit.jupiter.api.Test;
 
-/**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
- *
- * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.14.0
- */
-public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
+import static org.junit.jupiter.api.Assertions.*;
+
+class JacksonApnsPayloadBuilderTest extends ApnsPayloadBuilderTest {
 
     @Override
-    public String build() {
-        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
+    protected ApnsPayloadBuilder getBuilder() {
+        return new JacksonApnsPayloadBuilder();
     }
 
-    @Override
-    public String buildMdmPayload(final String pushMagicValue) {
-        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
+    @Test
+    void jacksonApnsPayloadBuilder() {
+        assertThrows(NullPointerException.class, () -> new JacksonApnsPayloadBuilder(null));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@
         <module>benchmark</module>
         <module>dropwizard-metrics-listener</module>
         <module>micrometer-metrics-listener</module>
+        <module>gson-payload-builder</module>
+        <module>jackson-payload-builder</module>
     </modules>
 
     <dependencyManagement>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -99,6 +99,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>com.helger.maven</groupId>
                 <artifactId>ph-javacc-maven-plugin</artifactId>
                 <version>4.1.3</version>

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -33,6 +33,8 @@ import java.util.*;
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
  * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">Generating a Remote Notification</a>
+ *
+ * @since 0.14.0
  */
 @SuppressWarnings({"UnusedReturnValue", "unused"})
 public abstract class ApnsPayloadBuilder {
@@ -810,7 +812,7 @@ public abstract class ApnsPayloadBuilder {
     /**
      * Returns a JSON representation of the push notification payload under construction.
      *
-     * @return a JSON representation of the payload under construction (possibly with an abbreviated alert body)
+     * @return a JSON representation of the payload under construction
      *
      * @see #buildPayloadMap()
      *

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.util;
+
+import com.eatthepath.json.JsonSerializer;
+
+public class SimpleApnsPayloadBuilder extends ApnsPayloadBuilder {
+
+    @Override
+    public String build() {
+        return JsonSerializer.writeJsonTextAsString(this.buildPayloadMap());
+    }
+
+    @Override
+    public String buildMdmPayload(final String pushMagicValue) {
+        return JsonSerializer.writeJsonTextAsString(this.buildMdmPayloadMap(pushMagicValue));
+    }
+}

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -30,6 +30,7 @@ import com.eatthepath.pushy.apns.server.MockApnsServerBuilder;
 import com.eatthepath.pushy.apns.server.MockApnsServerListener;
 import com.eatthepath.pushy.apns.server.PushNotificationHandlerFactory;
 import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.*;
 import org.junit.jupiter.api.AfterAll;
@@ -165,7 +166,7 @@ public class AbstractClientServerTest {
     }
 
     protected static String generateRandomPayload() {
-        final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
+        final ApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder();
         payloadBuilder.setAlertBody(UUID.randomUUID().toString());
 
         return payloadBuilder.build();

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ExampleApp.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ExampleApp.java
@@ -25,6 +25,7 @@ package com.eatthepath.pushy.apns;
 import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
 import com.eatthepath.pushy.apns.proxy.Socks5ProxyHandlerFactory;
 import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.eatthepath.pushy.apns.util.TokenUtil;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
@@ -76,7 +77,7 @@ public class ExampleApp {
         final SimpleApnsPushNotification pushNotification;
 
         {
-            final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
+            final ApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder();
             payloadBuilder.setAlertBody("Example!");
 
             final String payload = payloadBuilder.build();

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -38,13 +38,15 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class ApnsPayloadBuilderTest {
+public abstract class ApnsPayloadBuilderTest {
 
     private ApnsPayloadBuilder builder;
 
+    protected abstract ApnsPayloadBuilder getBuilder();
+
     @BeforeEach
     public void setUp() {
-        this.builder = new ApnsPayloadBuilder();
+        this.builder = getBuilder();
     }
 
     @Test
@@ -578,7 +580,7 @@ public class ApnsPayloadBuilderTest {
 
     @Test
     void testBuildMdmPayload() {
-        assertEquals("{\"mdm\":\"Magic!\"}", ApnsPayloadBuilder.buildMdmPayload("Magic!"));
+        assertEquals("{\"mdm\":\"Magic!\"}", builder.buildMdmPayload("Magic!"));
     }
 
     @SuppressWarnings("unchecked")

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.util;
+
+public class SimpleApnsPayloadBuilderTest extends ApnsPayloadBuilderTest {
+
+    @Override
+    protected ApnsPayloadBuilder getBuilder() {
+        return new SimpleApnsPayloadBuilder();
+    }
+}


### PR DESCRIPTION
This closes #678 and closes #696 by introducing GSON- and Jackson-backed payload builders in their own sub-modules. Pushy users will be able to add either (or neither) payload builder as a dependency as needed, and both allow callers to provide their own JSON serializers.

TODO:

- [x] Docs
- [x] READMEs
- [x] Examples