### PR TITLE
Make invalidation timestamps Optional

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
@@ -23,6 +23,7 @@
 package com.eatthepath.pushy.apns;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -78,13 +79,13 @@ public interface PushNotificationResponse<T extends ApnsPushNotification> {
      * to send notifications to the expired token unless the token has been re-registered more recently than the
      * returned timestamp.
      *
-     * @return the time at which APNs confirmed the token was no longer valid for the given topic, or {@code null} if
-     * the push notification was either accepted or rejected for a reason other than token invalidation
+     * @return the time at which APNs confirmed the token was no longer valid for the given topic, or empty if the push
+     * notification was either accepted or rejected for a reason other than token invalidation
      *
      * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947616">Sending
      * Notification Requests to APNs</a>
      *
      * @since 0.5
      */
-    Instant getTokenInvalidationTimestamp();
+    Optional<Instant> getTokenInvalidationTimestamp();
 }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
@@ -25,6 +25,7 @@ package com.eatthepath.pushy.apns;
 import com.eatthepath.uuid.FastUUID;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -68,8 +69,8 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     }
 
     @Override
-    public Instant getTokenInvalidationTimestamp() {
-        return this.tokenExpirationTimestamp;
+    public Optional<Instant> getTokenInvalidationTimestamp() {
+        return Optional.ofNullable(this.tokenExpirationTimestamp);
     }
 
     @Override

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
@@ -483,7 +483,7 @@ public class ApnsClientTest extends AbstractClientServerTest {
 
             assertFalse(response.isAccepted());
             assertEquals("Unregistered", response.getRejectionReason());
-            assertEquals(expiration.toEpochMilli(), response.getTokenInvalidationTimestamp().toEpochMilli());
+            assertEquals(expiration.toEpochMilli(), response.getTokenInvalidationTimestamp().map(Instant::toEpochMilli).orElse(0L));
         } finally {
             client.close().get();
             server.shutdown().get();


### PR DESCRIPTION
As an added bit of Java 8+ hygiene, we can return the expiration timestamp in push notification responses as an `Optional` to be clear that the timestamp won't always be present.