### PR TITLE
changed sh to bash in generate-certs.sh

### DIFF
--- a/pushy/script/generate-certs.sh
+++ b/pushy/script/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Generate a new, self-signed root CA
 openssl req -config openssl-custom.cnf -extensions v3_ca -new -x509 -days 36500 -nodes -subj "/CN=PushyTestRoot" -newkey rsa:2048 -sha512 -out ca.pem -keyout ca.key


### PR DESCRIPTION
error message when executing with sh
```
~/git/pushy/pushy/script$ ./generate-certs.sh 
Generating a RSA private key
......................................................................................................................................+++++
.....................................................................................+++++
writing new private key to 'ca.key'
-----
x509: Use -help for summary.
Generating a RSA private key
................+++++
.+++++
writing new private key to 'server-key.pem'
-----
x509: Use -help for summary.
Generating a RSA private key
.........................................................+++++
............................................+++++
writing new private key to 'single-topic-client.key'
-----
x509: Use -help for summary.
Generating a RSA private key
.........................................+++++
.....+++++
writing new private key to 'multi-topic-client.key'
-----
Can't open server-certs.pem for reading, No such file or directory
140657904542144:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:72:fopen('server-certs.pem','r')
140657904542144:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:79:
Can't open single-topic-client.pem for reading, No such file or directory
140689287942592:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:72:fopen('single-topic-client.pem','r')
140689287942592:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:79:
Can't open multi-topic-client.pem for reading, No such file or directory
139761754120640:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:72:fopen('multi-topic-client.pem','r')
139761754120640:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:79:
Can't open single-topic-client.pem for reading, No such file or directory
140532233011648:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:72:fopen('single-topic-client.pem','r')
140532233011648:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:79:
Keystore multiple-keys.jks wird in multiple-keys.p12 importiert...
Eintrag für Alias pair1 erfolgreich importiert.
Eintrag für Alias pair2 erfolgreich importiert.
Eintrag für Alias pair3 erfolgreich importiert.
Eintrag für Alias pair4 erfolgreich importiert.
Importbefehl abgeschlossen: 4 Einträge erfolgreich importiert, 0 Einträge nicht erfolgreich oder abgebrochen
rm: das Entfernen von 'server.key' ist nicht möglich: Datei oder Verzeichnis nicht gefunden
read EC key
writing EC key
```
