### PR TITLE
Cancel ping futures when channels close

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -498,6 +498,10 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     public void channelInactive(final ChannelHandlerContext context) throws Exception {
         super.channelInactive(context);
 
+        if (this.pingTimeoutFuture != null) {
+            this.pingTimeoutFuture.cancel(false);
+        }
+
         for (final PushNotificationFuture<?, ?> future : this.unattachedResponsePromisesByStreamId.values()) {
             future.completeExceptionally(STREAM_CLOSED_BEFORE_REPLY_EXCEPTION);
         }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -139,8 +139,8 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
     }
 
     @Override
-    protected void handlerRemoved0(final ChannelHandlerContext context) throws Exception {
-        super.handlerRemoved0(context);
+    public void channelInactive(final ChannelHandlerContext context) throws Exception {
+        super.channelInactive(context);
 
         // Cancel the token expiration future if it's still "live" to avoid a reference cycle that could keep handlers
         // for closed connections in memory longer than expected.


### PR DESCRIPTION
Tangentially-related to #811 and #816, this fixes an issue where ping futures could stay in play (and possibly keep a handler alive) longer than expected/desired. I think this was leading to some strange log output from threads that were no longer actually serving a channel.