### PR TITLE
Simplify authetication-related exceptions

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -34,8 +34,6 @@ import io.netty.util.concurrent.ScheduledFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.time.Duration;
 import java.time.Instant;
@@ -113,7 +111,7 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
                     log.debug("Proactively expiring authentication token for channel {}", context.channel());
                     TokenAuthenticationApnsClientHandler.this.authenticationToken = null;
                 }, tokenExpiration.toMillis(), TimeUnit.MILLISECONDS);
-            } catch (final NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
+            } catch (final SignatureException e) {
                 // This should never happen because we check the key/algorithm at signing key construction time.
                 log.error("Failed to generate authentication token for channel {}", context.channel(), e);
                 throw new RuntimeException(e);

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
@@ -29,8 +29,6 @@ import io.netty.util.AsciiString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.time.Duration;
 import java.time.Instant;
@@ -100,7 +98,7 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
             if (!authenticationToken.verifySignature(verificationKey)) {
                 throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
             }
-        } catch (final NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
+        } catch (final SignatureException e) {
             // This should never happen (here, at least) because we check keys at construction time. If something's
             // going to go wrong, it will go wrong before we ever get here.
             log.error("Failed to verify authentication token signature.", e);


### PR DESCRIPTION
This fixes #846 by making various signing-related exceptions unchecked (i.e. re-throwing them as a `RuntimeException`) in most contexts. The idea here is that we can—and already do—verify up-front that certain preconditions are true (the JVM supports the required algorithms and the key itself is valid). Once we've done that, we can assume that those preconditions are always met and don't need to ask callers to be dealing with exceptions that we know can't happen.

The diciest part here is dealing with `SignatureException`. It _is_ true that a `SignatureException` can still happen even once the "valid key" and "supported algorithm" checks have passed, but reading through the JDK source, it doesn't seem like there are any situations that could lead to a `SignatureException` that a caller can really deal with in any meaningful way. The most plausible paths to a `SignatureException` are errors like "you forgot to initialize your `Signature` object," but since all of those details are encapsulated, there's nothing a caller can do about them. There's a lower-probability set of causes where the data can be "bad" somehow (but we mooooostly control the data getting signed anyhow) or some bizarre confluence of random values used in the signing process produces unworkable values after many iterations. I don't think there's much a caller can do about those, either, and so I propose un-checking `SignatureException` in those cases, too.

While not a blocker, I bumped into this while working on a potential fix for #811, and it seemed worth addressing while I was at it.