### PR TITLE
Update to Jackson 2.12.1

### DIFF
--- a/jackson-payload-builder/README.md
+++ b/jackson-payload-builder/README.md
@@ -10,7 +10,7 @@ This module provides an [`ApnsPayloadBuilder`](https://pushy-apns.org/apidocs/0.
 </dependency>
 ```
 
-If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Jackson payload builder for Pushy depends on Pushy itself (obviously enough) and version 2.10 of the [Jackson databind library](https://github.com/FasterXML/jackson-databind).
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Jackson payload builder for Pushy depends on Pushy itself (obviously enough) and version 2.12 of the [Jackson databind library](https://github.com/FasterXML/jackson-databind).
 
 ## Using the Jackson payload builder
 

--- a/jackson-payload-builder/pom.xml
+++ b/jackson-payload-builder/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.12.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -71,7 +71,7 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.10/</link>
+                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.12/</link>
                         <link>https://pushy-apns.org/apidocs/0.14/</link>
                     </links>
                 </configuration>


### PR DESCRIPTION
This addresses [CVE-2020-25649](https://github.com/advisories/GHSA-288c-cq4h-88gq) by updating to the latest version of Jackson. I don't think there's any danger for Pushy, but it seems wise to update all the same.