### PR TITLE
Share authentication tokens between connections within a client

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
@@ -22,7 +22,7 @@
 
 package com.eatthepath.pushy.apns;
 
-import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import com.eatthepath.pushy.apns.auth.AuthenticationTokenProvider;
 import com.eatthepath.pushy.apns.proxy.ProxyHandlerFactory;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
@@ -71,7 +71,7 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
     static final AttributeKey<Promise<Channel>> CHANNEL_READY_PROMISE_ATTRIBUTE_KEY =
             AttributeKey.valueOf(ApnsChannelFactory.class, "channelReadyPromise");
 
-    ApnsChannelFactory(final SslContext sslContext, final ApnsSigningKey signingKey, final Duration tokenExpiration,
+    ApnsChannelFactory(final SslContext sslContext, final AuthenticationTokenProvider authenticationTokenProvider,
                        final ProxyHandlerFactory proxyHandlerFactory, final Duration connectTimeout,
                        final Duration idlePingInterval, final Duration gracefulShutdownTimeout,
                        final Http2FrameLogger frameLogger, final InetSocketAddress apnsServerAddress,
@@ -108,10 +108,9 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
                 {
                     final ApnsClientHandler.ApnsClientHandlerBuilder clientHandlerBuilder;
 
-                    if (signingKey != null) {
+                    if (authenticationTokenProvider != null) {
                         clientHandlerBuilder = new TokenAuthenticationApnsClientHandler.TokenAuthenticationApnsClientHandlerBuilder()
-                                .signingKey(signingKey)
-                                .tokenExpiration(tokenExpiration)
+                                .authenticationTokenProvider(authenticationTokenProvider)
                                 .authority(authority)
                                 .idlePingInterval(idlePingInterval);
                     } else {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
@@ -240,6 +240,10 @@ public class ApnsClient {
         return responseFuture;
     }
 
+    AuthenticationTokenProvider getAuthenticationTokenProvider() {
+        return this.authenticationTokenProvider;
+    }
+
     /**
      * <p>Gracefully shuts down the client, closing all connections and releasing all persistent resources. The
      * disconnection process will wait until notifications that have been sent to the APNs server have been either

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -561,10 +561,10 @@ public class ApnsClientBuilder {
         }
 
         try {
-            return new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
-                    this.tokenExpiration, this.proxyHandlerFactory, this.connectionTimeout,
-                    this.idlePingInterval, this.gracefulShutdownTimeout, this.concurrentConnections,
-                    this.metricsListener, this.frameLogger, this.eventLoopGroup);
+            return new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey, this.tokenExpiration,
+                    this.proxyHandlerFactory, this.connectionTimeout, this.idlePingInterval,
+                    this.gracefulShutdownTimeout, this.concurrentConnections,  this.metricsListener,
+                    this.frameLogger, this.eventLoopGroup);
         } finally {
             if (sslContext instanceof ReferenceCounted) {
                 ((ReferenceCounted) sslContext).release();

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenProvider.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An authentication token provider provides thread-safe, non-blocking access to a shared {@link AuthenticationToken}
+ * and refreshes its authentication token at regular intervals.
+ */
+public class AuthenticationTokenProvider implements Closeable {
+
+    private final ApnsSigningKey signingKey;
+    private final Clock clock;
+
+    private volatile AuthenticationToken token;
+
+    private final ScheduledFuture<?> refreshTokenFuture;
+
+    private static final Logger log = LoggerFactory.getLogger(AuthenticationTokenProvider.class);
+
+    /**
+     * Constructs a new authentication token provider that will generate authentication tokens using the given signing
+     * key and refresh the token at the given interval. Once constructed, callers <em>must</em> call the constructed
+     * instance's {@link #close()} method to cleanly dispose of the instance.
+     *
+     * @param signingKey the signing key to use to generate authentication tokens
+     * @param maxTokenAge the maximum age of an authentication token before a new token will be generated
+     * @param scheduledExecutorService an executor service to use to schedule token refresh tasks
+     */
+    public AuthenticationTokenProvider(final ApnsSigningKey signingKey, final Duration maxTokenAge, final ScheduledExecutorService scheduledExecutorService) {
+        this(signingKey, maxTokenAge, scheduledExecutorService, Clock.systemUTC());
+    }
+
+    /**
+     * Constructs a new authentication token provider that will generate authentication tokens using the given signing
+     * key and refresh the token at the given interval. Once constructed, callers <em>must</em> call the constructed
+     * instance's {@link #close()} method to cleanly dispose of the instance.
+     *
+     * @param signingKey the signing key to use to generate authentication tokens
+     * @param maxTokenAge the maximum age of an authentication token before a new token will be generated
+     * @param scheduledExecutorService an executor service to use to schedule token refresh tasks
+     * @param clock the clock to use to schedule tasks and manage token timestamps
+     */
+    AuthenticationTokenProvider(final ApnsSigningKey signingKey, final Duration maxTokenAge, final ScheduledExecutorService scheduledExecutorService, final Clock clock) {
+        this.signingKey = signingKey;
+        this.clock = clock;
+
+        this.token = new AuthenticationToken(signingKey, clock.instant());
+
+        this.refreshTokenFuture = scheduledExecutorService.scheduleAtFixedRate(this::refreshToken, maxTokenAge.toMillis(), maxTokenAge.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    void refreshToken() {
+        log.debug("Refreshed authentication token");
+        this.token = new AuthenticationToken(signingKey, clock.instant());
+    }
+
+    /**
+     * Returns a current authentication token. Subsequent calls to this method may, but are not guaranteed to, return
+     * the same token because tokens are refreshed at regular intervals. This method is thread-safe and can be called by
+     * any number of concurrent consumers.
+     *
+     * @return a current authentication token
+     */
+    public AuthenticationToken getAuthenticationToken() {
+        return this.token;
+    }
+
+    /**
+     * Shuts down this token provider, cancelling any recurring jobs to refresh tokens. Callers <em>must</em> call this
+     * method to cleanly dispose of an authentication token provider.
+     */
+    public void close() {
+        this.refreshTokenFuture.cancel(false);
+    }
+}

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
@@ -22,6 +22,7 @@
 
 package com.eatthepath.pushy.apns;
 
+import com.eatthepath.pushy.apns.auth.AuthenticationToken;
 import com.eatthepath.pushy.apns.server.*;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
@@ -341,6 +342,8 @@ public class ApnsClientTest extends AbstractClientServerTest {
         final TestClientMetricsListener metricsListener = new TestClientMetricsListener();
         final ApnsClient client = this.buildTokenAuthenticationClient(metricsListener);
 
+        final AuthenticationToken initialToken = client.getAuthenticationTokenProvider().getAuthenticationToken();
+
         try {
             server.start(PORT).get();
 
@@ -350,12 +353,13 @@ public class ApnsClientTest extends AbstractClientServerTest {
             final PushNotificationResponse<SimpleApnsPushNotification> response =
                     client.sendNotification(pushNotification).get();
 
-            assertFalse(response.isAccepted(),
-                    "Expired token failures should be fatal.");
+            assertFalse(response.isAccepted(), "Expired token failures should be fatal.");
         } finally {
             client.close().get();
             server.shutdown().get();
         }
+
+        assertNotEquals(initialToken, client.getAuthenticationTokenProvider().getAuthenticationToken());
     }
 
     @ParameterizedTest

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenProviderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenProviderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class AuthenticationTokenProviderTest {
+
+    private ScheduledExecutorService scheduledExecutorService;
+    private SettableClock clock;
+
+    private AuthenticationTokenProvider authenticationTokenProvider;
+
+    private static final String KEY_ID = "TESTKEY123";
+    private static final String TEAM_ID = "TEAMID0987";
+
+    private static class SettableClock extends Clock {
+
+        private Instant instant;
+
+        public SettableClock(final Instant initialTime) {
+            this.instant = initialTime;
+        }
+
+        public void setInstant(final Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.systemDefault();
+        }
+
+        @Override
+        public Clock withZone(final ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws NoSuchAlgorithmException, InvalidKeyException {
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.clock = new SettableClock(Instant.now());
+
+        final ApnsSigningKey signingKey = new ApnsSigningKey(KEY_ID, TEAM_ID, (ECPrivateKey) KeyPairUtil.generateKeyPair().getPrivate());
+
+        this.authenticationTokenProvider = new AuthenticationTokenProvider(signingKey, Duration.ofMinutes(50), scheduledExecutorService, clock);
+    }
+
+    @AfterEach
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    void tearDown() throws InterruptedException {
+        authenticationTokenProvider.close();
+
+        scheduledExecutorService.shutdown();
+        scheduledExecutorService.awaitTermination(2, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testRefreshToken() {
+        final Instant initialTime = clock.instant();
+        final AuthenticationToken initialToken = authenticationTokenProvider.getAuthenticationToken();
+
+        final Instant laterTime = initialTime.plus(Duration.ofHours(1));
+        clock.setInstant(laterTime);
+        authenticationTokenProvider.refreshToken();
+
+        assertNotEquals(initialToken, authenticationTokenProvider.getAuthenticationToken());
+        assertEquals(laterTime, authenticationTokenProvider.getAuthenticationToken().getIssuedAt());
+    }
+
+    @Test
+    void getAuthenticationToken() {
+        final AuthenticationToken authenticationToken = authenticationTokenProvider.getAuthenticationToken();
+
+        assertEquals(KEY_ID, authenticationToken.getKeyId());
+        assertEquals(TEAM_ID, authenticationToken.getTeamId());
+        assertEquals(clock.instant(), authenticationToken.getIssuedAt());
+    }
+}


### PR DESCRIPTION
In an effort to fix #811, this introduces an `AuthenticationTokenProvider` that allows multiple connections within an `ApnsClient` instance to share a single authentication token, reducing the number of token rotations over time.