### PR TITLE
Add methods with fallback if loc-key not found to ApnsPayloadBuilder

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -179,6 +179,31 @@ public abstract class ApnsPayloadBuilder {
     }
 
     /**
+     * <p>Sets the key of a message in the receiving app's localized string list to be shown for the push notification,
+     * along with a fallback for apps that do not have the given string in the string list.
+     * The message in the app's string list may optionally have placeholders, which will be populated by values from the
+     * given {@code alertArguments}. Clears any previously-set literal alert body.</p>
+     *
+     * <p>By default, no message is shown.</p>
+     *
+     * @param localizedAlertKey a key to a string in the receiving app's localized string list
+     * @param fallback the message to be shown for this push notification if the key does not exist
+     * @param alertArguments arguments to populate placeholders in the localized alert string; may be {@code null}
+     *
+     * @return a reference to this payload builder
+     *
+     * @see ApnsPayloadBuilder#setAlertBody(String)
+     */
+    public ApnsPayloadBuilder setLocalizedAlertMessageWithFallback(final String localizedAlertKey, final String fallback, final String... alertArguments) {
+        this.localizedAlertKey = localizedAlertKey;
+        this.localizedAlertArguments = (alertArguments != null && alertArguments.length > 0) ? alertArguments : null;
+
+        this.alertBody = fallback;
+
+        return this;
+    }
+
+    /**
      * <p>Sets a short description of the notification purpose. Clears any previously-set localized title key and
      * arguments. The Apple Watch will display the title as part of the notification. According to Apple's
      * documentation, this should be:</p>
@@ -224,6 +249,27 @@ public abstract class ApnsPayloadBuilder {
     }
 
     /**
+     * <p>Sets the key of the title string in the receiving app's localized string list to be shown for the push
+     * notification, along with a fallback for apps that do not have the given string in the string list.
+     * The message in the app's string list may optionally have placeholders, which will be populated by values from
+     * the given {@code alertArguments}.</p>
+     *
+     * @param localizedAlertTitleKey a key to a string in the receiving app's localized string list
+     * @param fallback the description to be shown for this push notification if the key does not exist
+     * @param alertTitleArguments arguments to populate placeholders in the localized alert string; may be {@code null}
+     *
+     * @return a reference to this payload builder
+     */
+    public ApnsPayloadBuilder setLocalizedAlertTitleWithFallback(final String localizedAlertTitleKey, final String fallback, final String... alertTitleArguments) {
+        this.localizedAlertTitleKey = localizedAlertTitleKey;
+        this.localizedAlertTitleArguments = (alertTitleArguments != null && alertTitleArguments.length > 0) ? alertTitleArguments : null;
+
+        this.alertTitle = fallback;
+
+        return this;
+    }
+
+    /**
      * <p>Sets a subtitle for the notification. Clears any previously-set localized subtitle key and arguments.</p>
      *
      * <p>By default, no subtitle is included. Requires iOS 10 or newer.</p>
@@ -242,6 +288,9 @@ public abstract class ApnsPayloadBuilder {
 
         return this;
     }
+
+
+
 
     /**
      * <p>Sets the key of the subtitle string in the receiving app's localized string list to be shown for the push
@@ -263,6 +312,32 @@ public abstract class ApnsPayloadBuilder {
         this.localizedAlertSubtitleArguments = (alertSubtitleArguments != null && alertSubtitleArguments.length > 0) ? alertSubtitleArguments : null;
 
         this.alertSubtitle = null;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the key of the subtitle string in the receiving app's localized string list to be shown for the push
+     * notification, along with a placeholder for apps that do not have the given string in the string list.
+     * The message in the app's string list may optionally have placeholders, which will be populated by values from
+     * the given {@code alertSubtitleArguments}.</p>
+     *
+     * <p>By default, no subtitle is included. Requires iOS 10 or newer.</p>
+     *
+     * @param localizedAlertSubtitleKey a key to a string in the receiving app's localized string list
+     * @param fallback the subtitle to be shown for this push notification if the key does not exist
+     * @param alertSubtitleArguments arguments to populate placeholders in the localized subtitle string; may be
+     * {@code null}
+     *
+     * @return a reference to this payload builder
+     *
+     * @since 0.8.1
+     */
+    public ApnsPayloadBuilder setLocalizedAlertSubtitleWithFallback(final String localizedAlertSubtitleKey, final String fallback, final String... alertSubtitleArguments) {
+        this.localizedAlertSubtitleKey = localizedAlertSubtitleKey;
+        this.localizedAlertSubtitleArguments = (alertSubtitleArguments != null && alertSubtitleArguments.length > 0) ? alertSubtitleArguments : null;
+
+        this.alertSubtitle = fallback;
 
         return this;
     }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -123,6 +123,43 @@ public abstract class ApnsPayloadBuilderTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSetLocalizedAlertBodyWithFallback() {
+        final String alertKey = "test.alert";
+        final String alertBodyFallback = "fallback";
+
+        this.builder.setAlertBody("Alert body!");
+        this.builder.setLocalizedAlertMessageWithFallback(alertKey, alertBodyFallback);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertKey, alert.get("loc-key"));
+            assertEquals(alertBodyFallback, alert.get("body"));
+            assertNull(alert.get("loc-args"));
+        }
+
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertMessageWithFallback(alertKey, null, (String[]) null);
+
+        final String[] alertArgs = new String[] { "Moose", "helicopter" };
+        this.builder.setLocalizedAlertMessageWithFallback(alertKey, alertBodyFallback, alertArgs);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertKey, alert.get("loc-key"));
+            assertEquals(alertBodyFallback, alert.get("body"));
+
+            final List<Object> argsArray = (List<Object>) alert.get("loc-args");
+            assertEquals(alertArgs.length, argsArray.size());
+            assertTrue(argsArray.containsAll(java.util.Arrays.asList(alertArgs)));
+        }
+    }
+
     @Test
     void testSetAlertTitle() {
         final String alertTitle = "This is a test alert message.";
@@ -182,6 +219,47 @@ public abstract class ApnsPayloadBuilderTest {
     }
 
     @Test
+    void testSetLocalizedAlertTitleWithFallback() {
+        final String localizedAlertTitleKey = "alert.title";
+        final String alertTitleFallback = "alertFallback";
+
+        this.builder.setAlertTitle("Alert title!");
+        this.builder.setLocalizedAlertTitleWithFallback(localizedAlertTitleKey, alertTitleFallback);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(localizedAlertTitleKey, alert.get("title-loc-key"));
+            assertEquals(alertTitleFallback, alert.get("title"));
+            assertNull(alert.get("title-loc-args"));
+        }
+
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertTitleWithFallback(localizedAlertTitleKey, null, (String[]) null);
+
+        final String[] alertArgs = new String[] { "Moose", "helicopter" };
+        this.builder.setLocalizedAlertTitleWithFallback(localizedAlertTitleKey, alertTitleFallback, alertArgs);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(localizedAlertTitleKey, alert.get("title-loc-key"));
+            assertEquals(alertTitleFallback, alert.get("title"));
+
+            @SuppressWarnings("unchecked")
+            final List<Object> argsArray = (List<Object>) alert.get("title-loc-args");
+            assertEquals(alertArgs.length, argsArray.size());
+            assertTrue(argsArray.containsAll(java.util.Arrays.asList(alertArgs)));
+        }
+    }
+
+    @Test
     void testSetAlertSubtitle() {
         final String alertSubtitle = "This is a test alert message.";
 
@@ -202,7 +280,7 @@ public abstract class ApnsPayloadBuilderTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testSetLocalizedAlertSubitle() {
+    void testSetLocalizedAlertSubtitle() {
         final String subtitleKey = "test.subtitle";
 
         this.builder.setAlertSubtitle("Subtitle!");
@@ -228,6 +306,43 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(subtitleKey, alert.get("subtitle-loc-key"));
+
+            final List<Object> argsArray = (List<Object>) alert.get("subtitle-loc-args");
+            assertEquals(subtitleArgs.length, argsArray.size());
+            assertTrue(argsArray.containsAll(java.util.Arrays.asList(subtitleArgs)));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSetLocalizedAlertSubtitleWithFallback() {
+        final String subtitleKey = "test.subtitle";
+        final String subtitleFallback = "fallback";
+
+        this.builder.setAlertSubtitle("Subtitle!");
+        this.builder.setLocalizedAlertSubtitleWithFallback(subtitleKey, subtitleFallback);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(subtitleKey, alert.get("subtitle-loc-key"));
+            assertEquals(subtitleFallback, alert.get("subtitle"));
+            assertNull(alert.get("subtitle-loc-args"));
+        }
+
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertTitleWithFallback(subtitleKey, null, (String[]) null);
+
+        final String[] subtitleArgs = new String[] { "Moose", "helicopter" };
+        this.builder.setLocalizedAlertTitleWithFallback(subtitleKey, subtitleFallback, subtitleArgs);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(subtitleKey, alert.get("subtitle-loc-key"));
+            assertEquals(subtitleFallback, alert.get("subtitle"));
 
             final List<Object> argsArray = (List<Object>) alert.get("subtitle-loc-args");
             assertEquals(subtitleArgs.length, argsArray.size());


### PR DESCRIPTION
While for most cases only setting one or the other of loc-key and body (and likewise for title, subtitle), we wish to be able to set body and title explicitly along with loc-keys to be backwards-compatible with users who have not yet updated their apps with new localization file. Does this seem like a sensible solution to the issue?