### PR TITLE
Explicitly close connections when we receive a GOAWAY

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -416,6 +416,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     @Override
     public void onGoAwayRead(final ChannelHandlerContext context, final int lastStreamId, final long errorCode, final ByteBuf debugData) {
         log.info("Received GOAWAY from APNs server: {}", debugData.toString(StandardCharsets.UTF_8));
+        context.close();
     }
 
     @Override


### PR DESCRIPTION
This fixes #865 by explicitly closing connections once we receive a `GOAWAY` frame from the APNs server.