### PR TITLE
Include the HTTP status code in response objects

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -325,7 +325,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         if (HttpResponseStatus.OK.equals(status)) {
             responseFuture.complete(new SimplePushNotificationResponse<>(responseFuture.getPushNotification(),
-                    true, getApnsIdFromHeaders(headers), null, null));
+                    true, getApnsIdFromHeaders(headers), status.code(), null, null));
         } else {
             if (data != null) {
                 ErrorResponse errorResponse;
@@ -352,8 +352,8 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         final HttpResponseStatus status = HttpResponseStatus.parseLine(headers.status());
 
         responseFuture.complete(new SimplePushNotificationResponse<>(responseFuture.getPushNotification(),
-                HttpResponseStatus.OK.equals(status), getApnsIdFromHeaders(headers), errorResponse.getReason(),
-                errorResponse.getTimestamp()));
+                HttpResponseStatus.OK.equals(status), getApnsIdFromHeaders(headers), status.code(),
+                errorResponse.getReason(), errorResponse.getTimestamp()));
     }
 
     private static UUID getApnsIdFromHeaders(final Http2Headers headers) {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
@@ -63,6 +63,15 @@ public interface PushNotificationResponse<T extends ApnsPushNotification> {
     UUID getApnsId();
 
     /**
+     * Returns the HTTP status code reported by the APNs server.
+     *
+     * @return the HTTP status code reported by the APNs server
+     *
+     * @since 0.15.0
+     */
+    int getStatusCode();
+
+    /**
      * Returns the reason for rejection reported by the APNs gateway. If the notification was accepted, the rejection
      * reason will be {@code null}.
      *

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
@@ -37,13 +37,15 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     private final T pushNotification;
     private final boolean success;
     private final UUID apnsId;
+    private final int statusCode;
     private final String rejectionReason;
     private final Instant tokenExpirationTimestamp;
 
-    SimplePushNotificationResponse(final T pushNotification, final boolean success, final UUID apnsId, final String rejectionReason, final Instant tokenExpirationTimestamp) {
+    SimplePushNotificationResponse(final T pushNotification, final boolean success, final UUID apnsId, final int statusCode, final String rejectionReason, final Instant tokenExpirationTimestamp) {
         this.pushNotification = pushNotification;
         this.success = success;
         this.apnsId = apnsId;
+        this.statusCode = statusCode;
         this.rejectionReason = rejectionReason;
         this.tokenExpirationTimestamp = tokenExpirationTimestamp;
     }
@@ -61,6 +63,11 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     @Override
     public UUID getApnsId() {
         return this.apnsId;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return this.statusCode;
     }
 
     @Override

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
@@ -396,6 +396,7 @@ public class ApnsClientTest extends AbstractClientServerTest {
                     "Clients must send notifications that conform to the APNs protocol specification.");
 
             assertNotNull(response.getApnsId());
+            assertEquals(200, response.getStatusCode());
         } finally {
             client.close().get();
             server.shutdown().get();


### PR DESCRIPTION
As requested in #840, this includes the HTTP status code from the APNs server in push notification responses.