### PR TITLE
Allow for literal and localized content in the same payload

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -135,10 +135,8 @@ public abstract class ApnsPayloadBuilder {
     }
 
     /**
-     * <p>Sets the literal text of the alert message to be shown for the push notification. Clears any previously-set
-     * localized alert message key and arguments.</p>
-     *
-     * <p>By default, no message is shown.</p>
+     * Sets the literal text of the alert message to be shown for the push notification. By default, no message is
+     * shown.
      *
      * @param alertBody the literal message to be shown for this push notification
      *
@@ -148,17 +146,13 @@ public abstract class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setAlertBody(final String alertBody) {
         this.alertBody = alertBody;
-
-        this.localizedAlertKey = null;
-        this.localizedAlertArguments = null;
-
         return this;
     }
 
     /**
      * <p>Sets the key of a message in the receiving app's localized string list to be shown for the push notification.
      * The message in the app's string list may optionally have placeholders, which will be populated by values from the
-     * given {@code alertArguments}. Clears any previously-set literal alert body.</p>
+     * given {@code alertArguments}.</p>
      *
      * <p>By default, no message is shown.</p>
      *
@@ -173,15 +167,12 @@ public abstract class ApnsPayloadBuilder {
         this.localizedAlertKey = localizedAlertKey;
         this.localizedAlertArguments = (alertArguments != null && alertArguments.length > 0) ? alertArguments : null;
 
-        this.alertBody = null;
-
         return this;
     }
 
     /**
-     * <p>Sets a short description of the notification purpose. Clears any previously-set localized title key and
-     * arguments. The Apple Watch will display the title as part of the notification. According to Apple's
-     * documentation, this should be:</p>
+     * <p>Sets a short description of the notification purpose. The Apple Watch will display the title as part of the
+     * notification. According to Apple's documentation, this should be:</p>
      *
      * <blockquote>A short string describing the purpose of the notification. Apple Watch displays this string as part
      * of the notification interface. This string is displayed only briefly and should be crafted so that it can be
@@ -197,17 +188,13 @@ public abstract class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setAlertTitle(final String alertTitle) {
         this.alertTitle = alertTitle;
-
-        this.localizedAlertTitleKey = null;
-        this.localizedAlertTitleArguments = null;
-
         return this;
     }
 
     /**
      * <p>Sets the key of the title string in the receiving app's localized string list to be shown for the push
-     * notification. Clears any previously-set literal alert title. The message in the app's string list may optionally
-     * have placeholders, which will be populated by values from the given {@code alertArguments}.</p>
+     * notification. The message in the app's string list may optionally have placeholders, which will be populated by
+     * values from the given {@code alertArguments}.</p>
      *
      * @param localizedAlertTitleKey a key to a string in the receiving app's localized string list
      * @param alertTitleArguments arguments to populate placeholders in the localized alert string; may be {@code null}
@@ -218,15 +205,11 @@ public abstract class ApnsPayloadBuilder {
         this.localizedAlertTitleKey = localizedAlertTitleKey;
         this.localizedAlertTitleArguments = (alertTitleArguments != null && alertTitleArguments.length > 0) ? alertTitleArguments : null;
 
-        this.alertTitle = null;
-
         return this;
     }
 
     /**
-     * <p>Sets a subtitle for the notification. Clears any previously-set localized subtitle key and arguments.</p>
-     *
-     * <p>By default, no subtitle is included. Requires iOS 10 or newer.</p>
+     * <p>Sets a subtitle for the notification. By default, no subtitle is included. Requires iOS 10 or newer.
      *
      * @param alertSubtitle the subtitle for this push notification
      *
@@ -237,16 +220,13 @@ public abstract class ApnsPayloadBuilder {
     public ApnsPayloadBuilder setAlertSubtitle(final String alertSubtitle) {
         this.alertSubtitle = alertSubtitle;
 
-        this.localizedAlertSubtitleKey = null;
-        this.localizedAlertSubtitleArguments = null;
-
         return this;
     }
 
     /**
      * <p>Sets the key of the subtitle string in the receiving app's localized string list to be shown for the push
-     * notification. Clears any previously-set literal subtitle. The message in the app's string list may optionally
-     * have placeholders, which will be populated by values from the given {@code alertSubtitleArguments}.</p>
+     * notification. The message in the app's string list may optionally have placeholders, which will be populated by
+     * values from the given {@code alertSubtitleArguments}.</p>
      *
      * <p>By default, no subtitle is included. Requires iOS 10 or newer.</p>
      *
@@ -261,8 +241,6 @@ public abstract class ApnsPayloadBuilder {
     public ApnsPayloadBuilder setLocalizedAlertSubtitle(final String localizedAlertSubtitleKey, final String... alertSubtitleArguments) {
         this.localizedAlertSubtitleKey = localizedAlertSubtitleKey;
         this.localizedAlertSubtitleArguments = (alertSubtitleArguments != null && alertSubtitleArguments.length > 0) ? alertSubtitleArguments : null;
-
-        this.alertSubtitle = null;
 
         return this;
     }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -53,18 +53,7 @@ public abstract class ApnsPayloadBuilderTest {
     void testSetAlertBody() {
         final String alertBody = "This is a test alert message.";
 
-        this.builder.setLocalizedAlertMessage("test.alert");
         this.builder.setAlertBody(alertBody);
-
-        {
-            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
-
-            assertEquals(alertBody, alert.get("body"));
-        }
-
         this.builder.setPreferStringRepresentationForAlerts(true);
 
         {
@@ -83,7 +72,7 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(alertBody, alert.get("body"));
-            assertNull(alert.get("loc-key"));
+            assertEquals("test.alert", alert.get("loc-key"));
             assertNull(alert.get("loc-args"));
         }
     }
@@ -101,8 +90,6 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(alertKey, alert.get("loc-key"));
-            assertNull(alert.get("loc-args"));
-            assertNull(alert.get("body"));
         }
 
         // We're happy here as long as nothing explodes
@@ -137,8 +124,6 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(alertTitle, alert.get("title"));
-            assertNull(alert.get("title-loc-key"));
-            assertNull(alert.get("title-loc-args"));
         }
     }
 
@@ -156,8 +141,6 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(localizedAlertTitleKey, alert.get("title-loc-key"));
-            assertNull(alert.get("title-loc-args"));
-            assertNull(alert.get("title"));
         }
 
         // We're happy here as long as nothing explodes
@@ -195,8 +178,6 @@ public abstract class ApnsPayloadBuilderTest {
             final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
 
             assertEquals(alertSubtitle, alert.get("subtitle"));
-            assertNull(alert.get("subtitle-loc-key"));
-            assertNull(alert.get("subtitle-loc-args"));
         }
     }
 
@@ -205,7 +186,6 @@ public abstract class ApnsPayloadBuilderTest {
     void testSetLocalizedAlertSubitle() {
         final String subtitleKey = "test.subtitle";
 
-        this.builder.setAlertSubtitle("Subtitle!");
         this.builder.setLocalizedAlertSubtitle(subtitleKey);
 
         {


### PR DESCRIPTION
As an alternative to #851, this alters the behavior of methods in `ApnsPayloadBuilder` that set literal or localized content such that literal/localized content are no longer mutually-exclusive.

This closes #799.