### PR TITLE
Change test action from `test` to `verify`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       env:
         PUSHY_TEST_TRANSPORT: ${{ matrix.transport }}
         PUSHY_TEST_SSL_PROVIDER: ${{ matrix.tls }}
-      run: mvn test -B --file pom.xml
+      run: mvn verify -B --file pom.xml

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -113,15 +113,16 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Import-Package>
                             <!-- Classes from the following packages are only loaded using Class.forName(), so BND can not detect they are required imports. -->
                             io.netty.channel.socket.nio,
-			    <!-- Avoid auto-import of exported packages -->
-			    !com.eatthepath.json,
-			    !com.eatthepath.pushy.*,
+                            <!-- Avoid auto-import of exported packages -->
+                            !com.eatthepath.json,
+                            !com.eatthepath.pushy.*,
                             <!-- This tells BND to add all other required imports that it does detect, as normal. -->
                             *,
                         </Import-Package>


### PR DESCRIPTION
It turns out we have some build issues (specifically https://github.com/bndtools/bnd/issues/3903) that weren't getting caught by running `mvn test` alone. This changes our GitHub Action to use `verify` instead of just `test`.