### PR TITLE
Update to fast-uuid 0.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>com.eatthepath</groupId>
                 <artifactId>fast-uuid</artifactId>
-                <version>0.1</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This updates to fast-uuid 0.2.0. fast-uuid 0.2.0 has no functional changes, but is packaged as an OSGi bundle (thanks, @MushyMiddle!). Combined with #871, this closes #862.