### PR TITLE
Use a configuration class for APNs client parameters

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -62,7 +62,7 @@ public class ApnsClientBuilder {
     private String privateKeyPassword;
 
     private ApnsSigningKey signingKey;
-    private Duration tokenExpiration = Duration.ofMinutes(50);
+    private Duration tokenExpiration;
 
     private File trustedServerCertificatePemFile;
     private InputStream trustedServerCertificateInputStream;
@@ -582,10 +582,21 @@ public class ApnsClientBuilder {
         }
 
         try {
-            return new ApnsClient(this.apnsServerAddress, sslContext, this.enableHostnameVerification, this.signingKey,
-                    this.tokenExpiration, this.proxyHandlerFactory, this.connectionTimeout, this.idlePingInterval,
-                    this.gracefulShutdownTimeout, this.concurrentConnections,  this.metricsListener,
-                    this.frameLogger, this.eventLoopGroup);
+            final ApnsClientConfiguration clientConfiguration =
+                    new ApnsClientConfiguration(this.apnsServerAddress,
+                            sslContext,
+                            this.enableHostnameVerification,
+                            this.signingKey,
+                            this.tokenExpiration,
+                            this.proxyHandlerFactory,
+                            this.connectionTimeout,
+                            this.idlePingInterval,
+                            this.gracefulShutdownTimeout,
+                            this.concurrentConnections,
+                            this.metricsListener,
+                            this.frameLogger);
+
+            return new ApnsClient(clientConfiguration, this.eventLoopGroup);
         } finally {
             if (sslContext instanceof ReferenceCounted) {
                 ((ReferenceCounted) sslContext).release();

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.apns;
+
+import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import com.eatthepath.pushy.apns.proxy.ProxyHandlerFactory;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.ssl.SslContext;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A simple carrier for APNs client configuration options.
+ */
+class ApnsClientConfiguration {
+
+    private static final Duration DEFAULT_TOKEN_EXPIRATION = Duration.ofMinutes(50);
+
+    private final InetSocketAddress apnsServerAddress;
+    private final SslContext sslContext;
+    private final boolean hostnameVerificationEnabled;
+    private final ApnsSigningKey signingKey;
+    private final Duration tokenExpiration;
+    private final ProxyHandlerFactory proxyHandlerFactory;
+    private final Duration connectionTimeout;
+    private final Duration idlePingInterval;
+    private final Duration gracefulShutdownTimeout;
+    private final int concurrentConnections;
+    private final ApnsClientMetricsListener metricsListener;
+    private final Http2FrameLogger frameLogger;
+
+    public ApnsClientConfiguration(final InetSocketAddress apnsServerAddress,
+                                   final SslContext sslContext,
+                                   final boolean hostnameVerificationEnabled,
+                                   final ApnsSigningKey signingKey,
+                                   final Duration tokenExpiration,
+                                   final ProxyHandlerFactory proxyHandlerFactory,
+                                   final Duration connectionTimeout,
+                                   final Duration idlePingInterval,
+                                   final Duration gracefulShutdownTimeout,
+                                   final int concurrentConnections,
+                                   final ApnsClientMetricsListener metricsListener,
+                                   final Http2FrameLogger frameLogger) {
+
+        this.apnsServerAddress = Objects.requireNonNull(apnsServerAddress);
+        this.sslContext = Objects.requireNonNull(sslContext);
+        this.hostnameVerificationEnabled = hostnameVerificationEnabled;
+        this.signingKey = signingKey;
+        this.tokenExpiration = tokenExpiration != null ? tokenExpiration : DEFAULT_TOKEN_EXPIRATION;
+        this.proxyHandlerFactory = proxyHandlerFactory;
+        this.connectionTimeout = connectionTimeout;
+        this.idlePingInterval = idlePingInterval;
+        this.gracefulShutdownTimeout = gracefulShutdownTimeout;
+        this.concurrentConnections = concurrentConnections;
+        this.metricsListener = metricsListener;
+        this.frameLogger = frameLogger;
+    }
+
+    public InetSocketAddress getApnsServerAddress() {
+        return apnsServerAddress;
+    }
+
+    public SslContext getSslContext() {
+        return sslContext;
+    }
+
+    public boolean isHostnameVerificationEnabled() {
+        return hostnameVerificationEnabled;
+    }
+
+    public Optional<ApnsSigningKey> getSigningKey() {
+        return Optional.ofNullable(signingKey);
+    }
+
+    public Duration getTokenExpiration() {
+        return tokenExpiration;
+    }
+
+    public Optional<ProxyHandlerFactory> getProxyHandlerFactory() {
+        return Optional.ofNullable(proxyHandlerFactory);
+    }
+
+    public Optional<Duration> getConnectionTimeout() {
+        return Optional.ofNullable(connectionTimeout);
+    }
+
+    public Duration getIdlePingInterval() {
+        return idlePingInterval;
+    }
+
+    public Optional<Duration> getGracefulShutdownTimeout() {
+        return Optional.ofNullable(gracefulShutdownTimeout);
+    }
+
+    public int getConcurrentConnections() {
+        return concurrentConnections;
+    }
+
+    public Optional<ApnsClientMetricsListener> getMetricsListener() {
+        return Optional.ofNullable(metricsListener);
+    }
+
+    public Optional<Http2FrameLogger> getFrameLogger() {
+        return Optional.ofNullable(frameLogger);
+    }
+}


### PR DESCRIPTION
As a bit of internal refactoring, this takes the (many) APNs client configuration options and packs them into a single configuration object that we can pass around to the various components of a client. This has no functional impact, but makes it a whole lot easier to add new options or remove old ones.