### PR TITLE
Close idle connections instead of sending `PING` frames

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
@@ -116,12 +116,10 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
                         clientHandlerBuilder = new TokenAuthenticationApnsClientHandler.TokenAuthenticationApnsClientHandlerBuilder()
                                 .signingKey(clientConfiguration.getSigningKey().get())
                                 .tokenExpiration(clientConfiguration.getTokenExpiration())
-                                .authority(authority)
-                                .idlePingInterval(clientConfiguration.getIdlePingInterval());
+                                .authority(authority);
                     } else {
                         clientHandlerBuilder = new ApnsClientHandler.ApnsClientHandlerBuilder()
-                                .authority(authority)
-                                .idlePingInterval(clientConfiguration.getIdlePingInterval());
+                                .authority(authority);
                     }
 
                     clientConfiguration.getFrameLogger().ifPresent(clientHandlerBuilder::frameLogger);
@@ -139,7 +137,7 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
 
                 pipeline.addLast(sslHandler);
                 pipeline.addLast(new FlushConsolidationHandler(FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true));
-                pipeline.addLast(new IdleStateHandler(clientConfiguration.getIdlePingInterval().toMillis(), 0, 0, TimeUnit.MILLISECONDS));
+                pipeline.addLast(new IdleStateHandler(clientConfiguration.getCloseAfterIdleDuration().toMillis(), 0, 0, TimeUnit.MILLISECONDS));
                 pipeline.addLast(apnsClientHandler);
             }
         });

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -79,17 +79,17 @@ public class ApnsClientBuilder {
     private ProxyHandlerFactory proxyHandlerFactory;
 
     private Duration connectionTimeout;
-    private Duration idlePingInterval = DEFAULT_IDLE_PING_INTERVAL;
+    private Duration closeAfterIdleDuration = DEFAULT_CLOSE_AFTER_IDLE_DURATION;
     private Duration gracefulShutdownTimeout;
 
     private Http2FrameLogger frameLogger;
 
     /**
-     * The default idle time in milliseconds after which the client will send a PING frame to the APNs server.
+     * The default idle time after which the client will close a connection (which may be reopened later).
      *
      * @since 0.11
      */
-    public static final Duration DEFAULT_IDLE_PING_INTERVAL = Duration.ofMinutes(1);
+    public static final Duration DEFAULT_CLOSE_AFTER_IDLE_DURATION = Duration.ofMinutes(1);
 
     /**
      * The hostname for the production APNs gateway.
@@ -474,18 +474,18 @@ public class ApnsClientBuilder {
     }
 
     /**
-     * Sets the amount of idle time (in milliseconds) after which the client under construction will send a PING frame
-     * to the APNs server. By default, clients will send a PING frame after an idle period of
-     * {@link com.eatthepath.pushy.apns.ApnsClientBuilder#DEFAULT_IDLE_PING_INTERVAL}.
+     * Sets the amount of idle time after which the client under construction will close a connection (which may be
+     * reopened later). By default, clients will close connections after an idle time of
+     * {@link com.eatthepath.pushy.apns.ApnsClientBuilder#DEFAULT_CLOSE_AFTER_IDLE_DURATION}.
      *
-     * @param idlePingInterval the amount of idle time after which the client will send a PING frame
+     * @param closeAfterIdleDuration the amount of idle time after which the client will close a connection
      *
      * @return a reference to this builder
      *
-     * @since 0.10
+     * @since 0.16.0
      */
-    public ApnsClientBuilder setIdlePingInterval(final Duration idlePingInterval) {
-        this.idlePingInterval = idlePingInterval;
+    public ApnsClientBuilder setCloseAfterIdleDuration(final Duration closeAfterIdleDuration) {
+        this.closeAfterIdleDuration = closeAfterIdleDuration;
         return this;
     }
 
@@ -590,7 +590,7 @@ public class ApnsClientBuilder {
                             this.tokenExpiration,
                             this.proxyHandlerFactory,
                             this.connectionTimeout,
-                            this.idlePingInterval,
+                            this.closeAfterIdleDuration,
                             this.gracefulShutdownTimeout,
                             this.concurrentConnections,
                             this.metricsListener,

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
@@ -46,7 +46,7 @@ class ApnsClientConfiguration {
     private final Duration tokenExpiration;
     private final ProxyHandlerFactory proxyHandlerFactory;
     private final Duration connectionTimeout;
-    private final Duration idlePingInterval;
+    private final Duration closeAfterIdleDuration;
     private final Duration gracefulShutdownTimeout;
     private final int concurrentConnections;
     private final ApnsClientMetricsListener metricsListener;
@@ -59,7 +59,7 @@ class ApnsClientConfiguration {
                                    final Duration tokenExpiration,
                                    final ProxyHandlerFactory proxyHandlerFactory,
                                    final Duration connectionTimeout,
-                                   final Duration idlePingInterval,
+                                   final Duration closeAfterIdleDuration,
                                    final Duration gracefulShutdownTimeout,
                                    final int concurrentConnections,
                                    final ApnsClientMetricsListener metricsListener,
@@ -72,7 +72,7 @@ class ApnsClientConfiguration {
         this.tokenExpiration = tokenExpiration != null ? tokenExpiration : DEFAULT_TOKEN_EXPIRATION;
         this.proxyHandlerFactory = proxyHandlerFactory;
         this.connectionTimeout = connectionTimeout;
-        this.idlePingInterval = idlePingInterval;
+        this.closeAfterIdleDuration = closeAfterIdleDuration;
         this.gracefulShutdownTimeout = gracefulShutdownTimeout;
         this.concurrentConnections = concurrentConnections;
         this.metricsListener = metricsListener;
@@ -107,8 +107,8 @@ class ApnsClientConfiguration {
         return Optional.ofNullable(connectionTimeout);
     }
 
-    public Duration getIdlePingInterval() {
-        return idlePingInterval;
+    public Duration getCloseAfterIdleDuration() {
+        return closeAfterIdleDuration;
     }
 
     public Optional<Duration> getGracefulShutdownTimeout() {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -81,14 +81,14 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
             Objects.requireNonNull(this.signingKey(), "Signing key must be set before building a TokenAuthenticationApnsClientHandler.");
             Objects.requireNonNull(this.tokenExpiration(), "Token expiration duration must be set before building a TokenAuthenticationApnsClientHandler.");
 
-            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.idlePingInterval(), this.signingKey(), this.tokenExpiration());
+            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.signingKey(), this.tokenExpiration());
             this.frameListener(handler);
             return handler;
         }
     }
 
-    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final Duration idlePingInterval, final ApnsSigningKey signingKey, final Duration tokenExpiration) {
-        super(decoder, encoder, initialSettings, authority, idlePingInterval);
+    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final ApnsSigningKey signingKey, final Duration tokenExpiration) {
+        super(decoder, encoder, initialSettings, authority);
 
         this.signingKey = Objects.requireNonNull(signingKey, "Signing key must not be null for token-based client handlers.");
         this.tokenExpiration = Objects.requireNonNull(tokenExpiration, "Token expiration must not be null for token-based client handlers");


### PR DESCRIPTION
This change simplifies handling of idle connections by simply closing them instead of continually sending `PING` frames.