### PR TITLE
Consolidate branches for loading trusted server certificates

### DIFF
--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyPair;
+import java.security.cert.CertificateException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.time.Instant;
@@ -110,11 +111,11 @@ public class AbstractClientServerTest {
         shutdownPromise.await();
     }
 
-    protected ApnsClient buildTlsAuthenticationClient() throws IOException {
+    protected ApnsClient buildTlsAuthenticationClient() throws IOException, CertificateException {
         return this.buildTlsAuthenticationClient(null);
     }
 
-    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException {
+    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException, CertificateException {
         try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             return new ApnsClientBuilder()
                     .setApnsServer(HOST, PORT)
@@ -126,11 +127,11 @@ public class AbstractClientServerTest {
         }
     }
 
-    protected ApnsClient buildTokenAuthenticationClient() throws SSLException {
+    protected ApnsClient buildTokenAuthenticationClient() throws SSLException, CertificateException {
         return this.buildTokenAuthenticationClient(null);
     }
 
-    protected ApnsClient buildTokenAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws SSLException {
+    protected ApnsClient buildTokenAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws SSLException, CertificateException {
         return new ApnsClientBuilder()
                 .setApnsServer(HOST, PORT)
                 .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))


### PR DESCRIPTION
Rather than having three different ways to pass trusted server certificates to the Netty `SslContext`, this change allows us load all of the certificates ourselves and then pass the resulting array to the `SslContext`. This has two effects:

1. It throws a new kind of checked exception earlier in the construction process, which is a breaking API change (but probably a good one)
2. It makes it much, much easier to eventually pull `SslContext` creation out of `ApnsClientBuilder` and into individual `ApnsChannelFactory` instances, which we need to do to support multiple sets of credentials within a single client (see #540).