### PR TITLE
Handle multiple sets of credentials with a single ApnsClient instance

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelFactory.java
@@ -116,12 +116,10 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
                         clientHandlerBuilder = new TokenAuthenticationApnsClientHandler.TokenAuthenticationApnsClientHandlerBuilder()
                                 .signingKey(clientConfiguration.getSigningKey().get())
                                 .tokenExpiration(clientConfiguration.getTokenExpiration())
-                                .authority(authority)
-                                .idlePingInterval(clientConfiguration.getIdlePingInterval());
+                                .authority(authority);
                     } else {
                         clientHandlerBuilder = new ApnsClientHandler.ApnsClientHandlerBuilder()
-                                .authority(authority)
-                                .idlePingInterval(clientConfiguration.getIdlePingInterval());
+                                .authority(authority);
                     }
 
                     clientConfiguration.getFrameLogger().ifPresent(clientHandlerBuilder::frameLogger);
@@ -139,7 +137,7 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
 
                 pipeline.addLast(sslHandler);
                 pipeline.addLast(new FlushConsolidationHandler(FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true));
-                pipeline.addLast(new IdleStateHandler(clientConfiguration.getIdlePingInterval().toMillis(), 0, 0, TimeUnit.MILLISECONDS));
+                pipeline.addLast(new IdleStateHandler(clientConfiguration.getCloseAfterIdleDuration().toMillis(), 0, 0, TimeUnit.MILLISECONDS));
                 pipeline.addLast(apnsClientHandler);
             }
         });

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
@@ -32,6 +32,8 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -135,8 +137,14 @@ public class ApnsClient {
         this.metricsListener = clientConfiguration.getMetricsListener()
                 .orElseGet(NoopApnsClientMetricsListener::new);
 
-        final ApnsChannelFactory channelFactory =
-                new ApnsChannelFactory(clientConfiguration, this.eventLoopGroup);
+        final ApnsChannelFactory channelFactory;
+
+        try {
+            channelFactory = new ApnsChannelFactory(clientConfiguration, this.eventLoopGroup);
+        } catch (final SSLException e) {
+            // TODO This is just temporary handling while the plumbing gets rearranged
+            throw new UncheckedIOException(e);
+        }
 
         final ApnsChannelPoolMetricsListener channelPoolMetricsListener = new ApnsChannelPoolMetricsListener() {
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -33,17 +33,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * An {@code ApnsClientBuilder} constructs new {@link ApnsClient} instances. Callers must specify the APNs server to
@@ -64,8 +66,6 @@ public class ApnsClientBuilder {
     private ApnsSigningKey signingKey;
     private Duration tokenExpiration;
 
-    private File trustedServerCertificatePemFile;
-    private InputStream trustedServerCertificateInputStream;
     private X509Certificate[] trustedServerCertificates;
 
     private boolean enableHostnameVerification = true;
@@ -316,12 +316,16 @@ public class ApnsClientBuilder {
      *
      * @return a reference to this builder
      *
+     * @throws CertificateException if certificates could not be loaded from the given file for any reason
+     *
      * @since 0.8
      */
-    public ApnsClientBuilder setTrustedServerCertificateChain(final File certificatePemFile) {
-        this.trustedServerCertificatePemFile = certificatePemFile;
-        this.trustedServerCertificateInputStream = null;
-        this.trustedServerCertificates = null;
+    public ApnsClientBuilder setTrustedServerCertificateChain(final File certificatePemFile) throws CertificateException {
+        try (final FileInputStream certificatePemInputStream = new FileInputStream(certificatePemFile)) {
+            this.setTrustedServerCertificateChain(certificatePemInputStream);
+        } catch (final IOException e) {
+            throw new CertificateException(e);
+        }
 
         return this;
     }
@@ -338,12 +342,20 @@ public class ApnsClientBuilder {
      *
      * @return a reference to this builder
      *
+     * @throws CertificateException if certificates could not be loaded from the given input stream for any reason
+     *
      * @since 0.8
      */
-    public ApnsClientBuilder setTrustedServerCertificateChain(final InputStream certificateInputStream) {
-        this.trustedServerCertificatePemFile = null;
-        this.trustedServerCertificateInputStream = certificateInputStream;
-        this.trustedServerCertificates = null;
+    public ApnsClientBuilder setTrustedServerCertificateChain(final InputStream certificateInputStream) throws CertificateException {
+        this.trustedServerCertificates = CertificateFactory.getInstance("X.509")
+                .generateCertificates(certificateInputStream)
+                .stream()
+                .map(certificate -> (X509Certificate) certificate)
+                .toArray(X509Certificate[]::new);
+
+        if (this.trustedServerCertificates.length == 0) {
+            log.warn("Trusted certificate chain has been set, but is empty");
+        }
 
         return this;
     }
@@ -363,10 +375,7 @@ public class ApnsClientBuilder {
      * @since 0.8
      */
     public ApnsClientBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
-        this.trustedServerCertificatePemFile = null;
-        this.trustedServerCertificateInputStream = null;
         this.trustedServerCertificates = certificates;
-
         return this;
     }
 
@@ -608,11 +617,7 @@ public class ApnsClientBuilder {
                 sslContextBuilder.keyManager(this.privateKey, this.privateKeyPassword, this.clientCertificate);
             }
 
-            if (this.trustedServerCertificatePemFile != null) {
-                sslContextBuilder.trustManager(this.trustedServerCertificatePemFile);
-            } else if (this.trustedServerCertificateInputStream != null) {
-                sslContextBuilder.trustManager(this.trustedServerCertificateInputStream);
-            } else if (this.trustedServerCertificates != null) {
+            if (this.trustedServerCertificates != null) {
                 sslContextBuilder.trustManager(this.trustedServerCertificates);
             }
 

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -79,7 +79,7 @@ public class ApnsClientBuilder {
     private ProxyHandlerFactory proxyHandlerFactory;
 
     private Duration connectionTimeout;
-    private Duration idlePingInterval = DEFAULT_IDLE_PING_INTERVAL;
+    private Duration closeAfterIdleDuration = DEFAULT_CLOSE_AFTER_IDLE_DURATION;
     private Duration gracefulShutdownTimeout;
 
     private Http2FrameLogger frameLogger;
@@ -87,11 +87,11 @@ public class ApnsClientBuilder {
     private boolean useAlpn = false;
 
     /**
-     * The default idle time in milliseconds after which the client will send a PING frame to the APNs server.
+     * The default idle time after which the client will close a connection (which may be reopened later).
      *
      * @since 0.11
      */
-    public static final Duration DEFAULT_IDLE_PING_INTERVAL = Duration.ofMinutes(1);
+    public static final Duration DEFAULT_CLOSE_AFTER_IDLE_DURATION = Duration.ofMinutes(1);
 
     /**
      * The hostname for the production APNs gateway.
@@ -485,18 +485,18 @@ public class ApnsClientBuilder {
     }
 
     /**
-     * Sets the amount of idle time (in milliseconds) after which the client under construction will send a PING frame
-     * to the APNs server. By default, clients will send a PING frame after an idle period of
-     * {@link com.eatthepath.pushy.apns.ApnsClientBuilder#DEFAULT_IDLE_PING_INTERVAL}.
+     * Sets the amount of idle time after which the client under construction will close a connection (which may be
+     * reopened later). By default, clients will close connections after an idle time of
+     * {@link com.eatthepath.pushy.apns.ApnsClientBuilder#DEFAULT_CLOSE_AFTER_IDLE_DURATION}.
      *
-     * @param idlePingInterval the amount of idle time after which the client will send a PING frame
+     * @param closeAfterIdleDuration the amount of idle time after which the client will close a connection
      *
      * @return a reference to this builder
      *
-     * @since 0.10
+     * @since 0.16.0
      */
-    public ApnsClientBuilder setIdlePingInterval(final Duration idlePingInterval) {
-        this.idlePingInterval = idlePingInterval;
+    public ApnsClientBuilder setCloseAfterIdleDuration(final Duration closeAfterIdleDuration) {
+        this.closeAfterIdleDuration = closeAfterIdleDuration;
         return this;
     }
 
@@ -633,7 +633,7 @@ public class ApnsClientBuilder {
                             this.tokenExpiration,
                             this.proxyHandlerFactory,
                             this.connectionTimeout,
-                            this.idlePingInterval,
+                            this.closeAfterIdleDuration,
                             this.gracefulShutdownTimeout,
                             this.concurrentConnections,
                             this.metricsListener,

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
@@ -46,7 +46,7 @@ class ApnsClientConfiguration {
     private final Duration tokenExpiration;
     private final ProxyHandlerFactory proxyHandlerFactory;
     private final Duration connectionTimeout;
-    private final Duration idlePingInterval;
+    private final Duration closeAfterIdleDuration;
     private final Duration gracefulShutdownTimeout;
     private final int concurrentConnections;
     private final ApnsClientMetricsListener metricsListener;
@@ -59,7 +59,7 @@ class ApnsClientConfiguration {
                                    final Duration tokenExpiration,
                                    final ProxyHandlerFactory proxyHandlerFactory,
                                    final Duration connectionTimeout,
-                                   final Duration idlePingInterval,
+                                   final Duration closeAfterIdleDuration,
                                    final Duration gracefulShutdownTimeout,
                                    final int concurrentConnections,
                                    final ApnsClientMetricsListener metricsListener,
@@ -72,7 +72,7 @@ class ApnsClientConfiguration {
         this.tokenExpiration = tokenExpiration != null ? tokenExpiration : DEFAULT_TOKEN_EXPIRATION;
         this.proxyHandlerFactory = proxyHandlerFactory;
         this.connectionTimeout = connectionTimeout;
-        this.idlePingInterval = idlePingInterval;
+        this.closeAfterIdleDuration = closeAfterIdleDuration;
         this.gracefulShutdownTimeout = gracefulShutdownTimeout;
         this.concurrentConnections = concurrentConnections;
         this.metricsListener = metricsListener;
@@ -107,8 +107,8 @@ class ApnsClientConfiguration {
         return Optional.ofNullable(connectionTimeout);
     }
 
-    public Duration getIdlePingInterval() {
-        return idlePingInterval;
+    public Duration getCloseAfterIdleDuration() {
+        return closeAfterIdleDuration;
     }
 
     public Optional<Duration> getGracefulShutdownTimeout() {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientConfiguration.java
@@ -23,11 +23,12 @@
 package com.eatthepath.pushy.apns;
 
 import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import com.eatthepath.pushy.apns.auth.CertificateAndPrivateKey;
 import com.eatthepath.pushy.apns.proxy.ProxyHandlerFactory;
 import io.netty.handler.codec.http2.Http2FrameLogger;
-import io.netty.handler.ssl.SslContext;
 
 import java.net.InetSocketAddress;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
@@ -40,9 +41,11 @@ class ApnsClientConfiguration {
     private static final Duration DEFAULT_TOKEN_EXPIRATION = Duration.ofMinutes(50);
 
     private final InetSocketAddress apnsServerAddress;
-    private final SslContext sslContext;
     private final boolean hostnameVerificationEnabled;
+    private final CertificateAndPrivateKey certificateAndPrivateKey;
     private final ApnsSigningKey signingKey;
+    private final X509Certificate[] trustedServerCertificates;
+    private final boolean useAlpn;
     private final Duration tokenExpiration;
     private final ProxyHandlerFactory proxyHandlerFactory;
     private final Duration connectionTimeout;
@@ -53,9 +56,11 @@ class ApnsClientConfiguration {
     private final Http2FrameLogger frameLogger;
 
     public ApnsClientConfiguration(final InetSocketAddress apnsServerAddress,
-                                   final SslContext sslContext,
                                    final boolean hostnameVerificationEnabled,
                                    final ApnsSigningKey signingKey,
+                                   final CertificateAndPrivateKey certificateAndPrivateKey,
+                                   final X509Certificate[] trustedServerCertificates,
+                                   final boolean useAlpn,
                                    final Duration tokenExpiration,
                                    final ProxyHandlerFactory proxyHandlerFactory,
                                    final Duration connectionTimeout,
@@ -66,9 +71,11 @@ class ApnsClientConfiguration {
                                    final Http2FrameLogger frameLogger) {
 
         this.apnsServerAddress = Objects.requireNonNull(apnsServerAddress);
-        this.sslContext = Objects.requireNonNull(sslContext);
         this.hostnameVerificationEnabled = hostnameVerificationEnabled;
         this.signingKey = signingKey;
+        this.certificateAndPrivateKey = certificateAndPrivateKey;
+        this.trustedServerCertificates = trustedServerCertificates;
+        this.useAlpn = useAlpn;
         this.tokenExpiration = tokenExpiration != null ? tokenExpiration : DEFAULT_TOKEN_EXPIRATION;
         this.proxyHandlerFactory = proxyHandlerFactory;
         this.connectionTimeout = connectionTimeout;
@@ -83,16 +90,24 @@ class ApnsClientConfiguration {
         return apnsServerAddress;
     }
 
-    public SslContext getSslContext() {
-        return sslContext;
-    }
-
     public boolean isHostnameVerificationEnabled() {
         return hostnameVerificationEnabled;
     }
 
     public Optional<ApnsSigningKey> getSigningKey() {
         return Optional.ofNullable(signingKey);
+    }
+
+    public CertificateAndPrivateKey getCertificateAndPrivateKey() {
+        return certificateAndPrivateKey;
+    }
+
+    public X509Certificate[] getTrustedServerCertificates() {
+        return trustedServerCertificates;
+    }
+
+    public boolean getUseAlpn() {
+        return useAlpn;
     }
 
     public Duration getTokenExpiration() {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -38,22 +38,18 @@ import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.AsciiString;
 import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseCombiner;
-import io.netty.util.concurrent.ScheduledFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameListener, Http2Connection.Listener {
 
@@ -64,9 +60,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private final Http2Connection.PropertyKey streamErrorCausePropertyKey;
 
     private final String authority;
-
-    private final Duration pingTimeout;
-    private ScheduledFuture<?> pingTimeoutFuture;
 
     private Throwable connectionErrorCause;
 
@@ -92,7 +85,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     public static class ApnsClientHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<ApnsClientHandler, ApnsClientHandlerBuilder> {
 
         private String authority;
-        private Duration idlePingInterval;
 
         ApnsClientHandlerBuilder authority(final String authority) {
             this.authority = authority;
@@ -101,15 +93,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         String authority() {
             return this.authority;
-        }
-
-        Duration idlePingInterval() {
-            return idlePingInterval;
-        }
-
-        ApnsClientHandlerBuilder idlePingInterval(final Duration idlePingIntervalMillis) {
-            this.idlePingInterval = idlePingIntervalMillis;
-            return this;
         }
 
         @Override
@@ -136,7 +119,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         public ApnsClientHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
             Objects.requireNonNull(this.authority(), "Authority must be set before building an ApnsClientHandler.");
 
-            final ApnsClientHandler handler = new ApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.idlePingInterval());
+            final ApnsClientHandler handler = new ApnsClientHandler(decoder, encoder, initialSettings, this.authority());
             this.frameListener(handler);
             return handler;
         }
@@ -147,7 +130,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
     }
 
-    ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final Duration idlePingInterval) {
+    ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority) {
         super(decoder, encoder, initialSettings);
 
         this.authority = authority;
@@ -157,8 +140,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         this.streamErrorCausePropertyKey = this.connection().newKey();
 
         this.connection().addListener(this);
-
-        this.pingTimeout = idlePingInterval.dividedBy(2);
     }
 
     @Override
@@ -264,22 +245,8 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     @Override
     public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
         if (event instanceof IdleStateEvent) {
-            log.trace("Sending ping due to inactivity.");
-
-            this.encoder().writePing(context, false, System.currentTimeMillis(), context.newPromise()).addListener(
-                    (GenericFutureListener<ChannelFuture>) future -> {
-                        if (!future.isSuccess()) {
-                            log.debug("Failed to write PING frame.", future.cause());
-                            future.channel().close();
-                        }
-                    });
-
-            this.pingTimeoutFuture = context.channel().eventLoop().schedule(() -> {
-                log.debug("Closing channel due to ping timeout.");
-                context.channel().close();
-            }, pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
-
-            this.flush(context);
+            log.debug("Closing idle channel.");
+            context.close();
         }
 
         super.userEventTriggered(context, event);
@@ -413,11 +380,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
     @Override
     public void onPingAckRead(final ChannelHandlerContext context, final long pingData) {
-        if (this.pingTimeoutFuture != null) {
-            this.pingTimeoutFuture.cancel(false);
-        } else {
-            log.error("Received PING ACK, but no corresponding outbound PING found.");
-        }
     }
 
     @Override
@@ -508,10 +470,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
     @Override
     public void channelInactive(final ChannelHandlerContext context) throws Exception {
-        if (this.pingTimeoutFuture != null) {
-            this.pingTimeoutFuture.cancel(false);
-        }
-
         for (final PushNotificationFuture<?, ?> future : this.unattachedResponsePromisesByStreamId.values()) {
             future.completeExceptionally(STREAM_CLOSED_BEFORE_REPLY_EXCEPTION);
         }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -81,14 +81,14 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
             Objects.requireNonNull(this.signingKey(), "Signing key must be set before building a TokenAuthenticationApnsClientHandler.");
             Objects.requireNonNull(this.tokenExpiration(), "Token expiration duration must be set before building a TokenAuthenticationApnsClientHandler.");
 
-            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.idlePingInterval(), this.signingKey(), this.tokenExpiration());
+            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.signingKey(), this.tokenExpiration());
             this.frameListener(handler);
             return handler;
         }
     }
 
-    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final Duration idlePingInterval, final ApnsSigningKey signingKey, final Duration tokenExpiration) {
-        super(decoder, encoder, initialSettings, authority, idlePingInterval);
+    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final ApnsSigningKey signingKey, final Duration tokenExpiration) {
+        super(decoder, encoder, initialSettings, authority);
 
         this.signingKey = Objects.requireNonNull(signingKey, "Signing key must not be null for token-based client handlers.");
         this.tokenExpiration = Objects.requireNonNull(tokenExpiration, "Token expiration must not be null for token-based client handlers");

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsSigningKey.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/ApnsSigningKey.java
@@ -31,6 +31,8 @@ import java.security.Signature;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * A private key used to sign authentication tokens. Signing keys are associated with a developer team (in Apple's
@@ -87,6 +89,21 @@ public class ApnsSigningKey extends ApnsKey implements ECPrivateKey {
     @Override
     public BigInteger getS() {
         return this.getKey().getS();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ApnsSigningKey)) return false;
+        final ApnsSigningKey apnsSigningKey = (ApnsSigningKey) o;
+        return Objects.equals(getTeamId(), apnsSigningKey.getTeamId()) &&
+            Objects.equals(getKeyId(), apnsSigningKey.getKeyId()) &&
+            Arrays.equals(getEncoded(), apnsSigningKey.getEncoded());
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hash(getTeamId(), getKey()) + Arrays.hashCode(getEncoded());
     }
 
     /**

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/CertificateAndPrivateKey.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/CertificateAndPrivateKey.java
@@ -1,0 +1,102 @@
+package com.eatthepath.pushy.apns.auth;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A carrier class for certificate-and-private-key pairs used to authenticate clients to APNs servers.
+ */
+public class CertificateAndPrivateKey {
+
+  private final X509Certificate certificate;
+  private final PrivateKey privateKey;
+
+  public CertificateAndPrivateKey(final X509Certificate certificate, final PrivateKey privateKey) {
+    this.certificate = certificate;
+    this.privateKey = privateKey;
+  }
+
+  /**
+   * Returns the X.509 certificate in this certificate/private key pair.
+   *
+   * @return the X.509 certificate in this certificate/private key pair
+   */
+  public X509Certificate getCertificate() {
+    return certificate;
+  }
+
+  /**
+   * Returns the private key in this certificate/private key pair.
+   *
+   * @return the private key in this certificate/private key pair
+   */
+  public PrivateKey getPrivateKey() {
+    return privateKey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final CertificateAndPrivateKey that = (CertificateAndPrivateKey) o;
+    return Objects.equals(certificate, that.certificate) && Arrays.equals(privateKey.getEncoded(), that.privateKey.getEncoded());
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Objects.hash(certificate) + Arrays.hashCode(privateKey.getEncoded());
+  }
+
+  /**
+   * Loads a certificate and private key from the given PKCS#12 file. If more than one certificate/key pair is found in
+   * the given file, which one is loaded is undefined.
+   *
+   * @param p12File the file from which to laod a certificate and private key
+   * @param p12Password the password to be used to decrypt the PKCS#12 file
+   *
+   * @return a certificate and private key loaded from the given PKCS#12 file
+   *
+   * @throws IOException if the given file could not be read for any reason
+   * @throws KeyStoreException if the given file could be read, but a certificate/key could not be loaded for any other
+   * reason
+   */
+  public static CertificateAndPrivateKey fromP12File(final File p12File, final String p12Password) throws IOException, KeyStoreException {
+    try (final InputStream p12InputStream = Files.newInputStream(p12File.toPath())) {
+      return fromP12InputStream(p12InputStream, p12Password);
+    }
+  }
+
+  /**
+   * Loads a certificate and private key from the given PKCS#12 input stream. If more than one certificate/key pair is
+   * found in the given input stream, which one is loaded is undefined.
+   *
+   * @param p12InputStream the input stream from which to laod a certificate and private key
+   * @param p12Password the password to be used to decrypt the PKCS#12 input stream
+   *
+   * @return a certificate and private key loaded from the given PKCS#12 input stream
+   *
+   * @throws IOException if the given input stream could not be read for any reason
+   * @throws KeyStoreException if the given input stream could be read, but a certificate/key could not be loaded for
+   * any other reason
+   */
+  public static CertificateAndPrivateKey fromP12InputStream(final InputStream p12InputStream, final String p12Password) throws IOException, KeyStoreException {
+    final KeyStore.PrivateKeyEntry privateKeyEntry = P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, p12Password);
+
+    final Certificate certificate = privateKeyEntry.getCertificate();
+
+    if (!(certificate instanceof X509Certificate)) {
+      throw new KeyStoreException("Found a certificate in the provided PKCS#12 file, but it was not an X.509 certificate.");
+    }
+
+    return new CertificateAndPrivateKey((X509Certificate) certificate, privateKeyEntry.getPrivateKey());
+  }
+}

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/P12Util.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/P12Util.java
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-package com.eatthepath.pushy.apns;
+package com.eatthepath.pushy.apns.auth;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyPair;
+import java.security.KeyStoreException;
 import java.security.cert.CertificateException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -108,11 +109,11 @@ public class AbstractClientServerTest {
         shutdownPromise.await();
     }
 
-    protected ApnsClient buildTlsAuthenticationClient() throws IOException, CertificateException {
+    protected ApnsClient buildTlsAuthenticationClient() throws IOException, CertificateException, KeyStoreException {
         return this.buildTlsAuthenticationClient(null);
     }
 
-    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException, CertificateException {
+    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException, CertificateException, KeyStoreException {
         try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             return new ApnsClientBuilder()
                     .setApnsServer(HOST, PORT)

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyPair;
+import java.security.cert.CertificateException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.time.Instant;
@@ -107,11 +108,11 @@ public class AbstractClientServerTest {
         shutdownPromise.await();
     }
 
-    protected ApnsClient buildTlsAuthenticationClient() throws IOException {
+    protected ApnsClient buildTlsAuthenticationClient() throws IOException, CertificateException {
         return this.buildTlsAuthenticationClient(null);
     }
 
-    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException {
+    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException, CertificateException {
         try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             return new ApnsClientBuilder()
                     .setApnsServer(HOST, PORT)
@@ -123,11 +124,11 @@ public class AbstractClientServerTest {
         }
     }
 
-    protected ApnsClient buildTokenAuthenticationClient() throws SSLException {
+    protected ApnsClient buildTokenAuthenticationClient() throws SSLException, CertificateException {
         return this.buildTokenAuthenticationClient(null);
     }
 
-    protected ApnsClient buildTokenAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws SSLException {
+    protected ApnsClient buildTokenAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws SSLException, CertificateException {
         return new ApnsClientBuilder()
                 .setApnsServer(HOST, PORT)
                 .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/auth/P12UtilTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/auth/P12UtilTest.java
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-package com.eatthepath.pushy.apns;
+package com.eatthepath.pushy.apns.auth;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Implementing multiple sets of credentials within a single client (which will close #540) will be no small feat. For now, this is an integration branch that serves two purposes:

1. It provides a home for a big, wide-ranging development project without making undue noise in `main`
2. It provides visibility into the effort

In time, this will become a more serious "for actual review" branch, but for now, it's just a draft and a bit of a holding area.