### PR TITLE
Update to gson 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/jchambers/pushy/releases/download/pushy-0.15.1/pushy-0.15.1.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
 - [netty 4.1.74](http://netty.io/)
-- [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 

--- a/gson-payload-builder/pom.xml
+++ b/gson-payload-builder/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This updates to gson 2.9.0 to address [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57). CVE-2022-25647 doesn't affect Pushy because we never use gson to deserialize JSON (we only ever use it to serialize payloads, and then only if users opt in to the gson module), but it seems wise to update all the same.