### PR TITLE
ApnsPayloadBuilder check custom property key not `aps`

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -704,8 +704,13 @@ public abstract class ApnsPayloadBuilder {
      * @param value the value of the custom property
      *
      * @return a reference to this payload builder
+     *
+     * @throws IllegalArgumentException if the key equals to "aps"
      */
     public ApnsPayloadBuilder addCustomProperty(final String key, final Object value) {
+        if (APS_KEY.equals(key)) {
+            throw new IllegalArgumentException("Custom property key must not be aps");
+        }
         this.customProperties.put(key, value);
         return this;
     }


### PR DESCRIPTION
A check to avoid accidentally overwriting the important `aps` field.