### PR TITLE
Clarify custom property serialization

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -22,8 +22,6 @@
 
 package com.eatthepath.pushy.apns.util;
 
-import com.eatthepath.json.JsonSerializer;
-
 import java.util.*;
 
 /**
@@ -698,7 +696,8 @@ public abstract class ApnsPayloadBuilder {
      * identifying when the provider sent the notification. Any action associated with an alert message should not be
      * destructive—for example, it should not delete data on the device.</blockquote>
      *
-     * <p>The value for the property is serialized to JSON as described in {@link JsonSerializer}.</p>
+     * <p>The precise strategy for serializing the values of custom properties is defined by the specific
+     * {@code ApnsPayloadBuilder} implementation.</p>
      *
      * @param key the key of the custom property in the payload object
      * @param value the value of the custom property
@@ -711,6 +710,7 @@ public abstract class ApnsPayloadBuilder {
         if (APS_KEY.equals(key)) {
             throw new IllegalArgumentException("Custom property key must not be aps");
         }
+
         this.customProperties.put(key, value);
         return this;
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -844,9 +844,7 @@ public abstract class ApnsPayloadBuilder {
             payload.put(APS_KEY, aps);
         }
 
-        for (final Map.Entry<String, Object> entry : this.customProperties.entrySet()) {
-            payload.put(entry.getKey(), entry.getValue());
-        }
+        payload.putAll(this.customProperties);
 
         return payload;
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPayloadBuilder.java
@@ -25,7 +25,8 @@ package com.eatthepath.pushy.apns.util;
 import com.eatthepath.json.JsonSerializer;
 
 /**
- * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}.
+ * A simple APNs payload builder that serializes payloads using a {@link JsonSerializer}. Please see the documentation
+ * for {@link JsonSerializer} for details about how this payload builder serializes custom properties.
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -517,14 +518,25 @@ public abstract class ApnsPayloadBuilderTest {
 
     @Test
     void testAddCustomProperty() throws ParseException {
-        final String customKey = "string";
-        final String customValue = "Hello";
+        final String keyForStringValue = "string";
+        final String stringValue = "Hello";
 
-        this.builder.addCustomProperty(customKey, customValue);
+        final String keyForLongValue = "integer";
+        final long longValue = 12;
+
+        final String keyForMapValue = "map";
+        final Map<String, Boolean> mapValue = new HashMap<>();
+        mapValue.put("boolean", true);
+
+        this.builder.addCustomProperty(keyForStringValue, stringValue);
+        this.builder.addCustomProperty(keyForLongValue, longValue);
+        this.builder.addCustomProperty(keyForMapValue, mapValue);
 
         final Map<String, Object> payload = new JsonParser().parseJsonObject(this.builder.build());
 
-        assertEquals(customValue, payload.get(customKey));
+        assertEquals(stringValue, payload.get(keyForStringValue));
+        assertEquals(longValue, payload.get(keyForLongValue));
+        assertEquals(mapValue, payload.get(keyForMapValue));
     }
 
     @Test


### PR DESCRIPTION
The documentation for `ApnsPayloadBuilder#addCustomProperty(String, Object)` says, in part:

> The value for the property is serialized to JSON as described in [`JsonSerializer`](https://pushy-apns.org/apidocs/0.15/com/eatthepath/json/JsonSerializer.html).

That's not entirely correct; different implementations of `ApnsPayloadBuilder` may use different strategies for serializing custom objects (and, in fact, that's often the point of using them in the first place). This change clarifies that the serialization of custom properties is implementation-dependent.

This closes #974.