### PR TITLE
Update to Netty 4.1.85

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/jchambers/pushy/releases/download/pushy-0.15.1/pushy-0.15.1.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.74](http://netty.io/)
+- [netty 4.1.85](http://netty.io/)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
@@ -41,7 +41,7 @@ Pushy itself requires Java 8 or newer to build and run. While not required, user
 <dependency>
     <groupId>io.netty</groupId>
     <artifactId>netty-tcnative-boringssl-static</artifactId>
-    <version>2.0.50.Final</version>
+    <version>2.0.54.Final</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.50.Final</version>
+                <version>2.0.54.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>
@@ -154,7 +154,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.74.Final</netty.version>
+        <netty.version>4.1.85.Final</netty.version>
         <junit.version>5.6.0</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This updates to the latest version of Netty. I don't believe we _need_ anything in the most recent updates, but it still seems wise to keep on top of things.

This also closes #995.