### PR TITLE
Simplify authentication token encoding/decoding and verification

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -138,8 +138,8 @@ public class AuthenticationToken {
     private final AuthenticationTokenClaims claims;
     private final byte[] signatureBytes;
 
-    private transient final String base64EncodedToken;
-    private transient final AsciiString authorizationHeader;
+    private final String base64EncodedToken;
+    private final AsciiString authorizationHeader;
 
     /**
      * Constructs a new authentication token using the given signing key (and associated metadata) issued at the given

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -163,7 +163,6 @@ public class AuthenticationToken {
         payloadBuilder.append('.');
         payloadBuilder.append(encodeUnpaddedBase64UrlString(claimsJson.getBytes(StandardCharsets.US_ASCII)));
 
-        //noinspection TryWithIdenticalCatches
         try {
             final Signature signature = Signature.getInstance(ApnsKey.APNS_SIGNATURE_ALGORITHM);
             signature.initSign(signingKey);
@@ -186,7 +185,7 @@ public class AuthenticationToken {
         payloadBuilder.append(encodeUnpaddedBase64UrlString(this.signatureBytes));
 
         this.base64EncodedToken = payloadBuilder.toString();
-        this.authorizationHeader = new AsciiString("bearer " + payloadBuilder.toString());
+        this.authorizationHeader = new AsciiString("bearer " + payloadBuilder);
     }
 
     /**
@@ -273,18 +272,9 @@ public class AuthenticationToken {
             return false;
         }
 
-        final byte[] headerAndClaimsBytes;
+        final byte[] headerAndClaimsBytes =
+            base64EncodedToken.substring(0, base64EncodedToken.lastIndexOf('.')).getBytes(StandardCharsets.UTF_8);
 
-        final String headerJson = JsonSerializer.writeJsonTextAsString(this.header.toMap());
-        final String claimsJson = JsonSerializer.writeJsonTextAsString(this.claims.toMap());
-
-        final String encodedHeaderAndClaims =
-                encodeUnpaddedBase64UrlString(headerJson.getBytes(StandardCharsets.US_ASCII)) + '.' +
-                encodeUnpaddedBase64UrlString(claimsJson.getBytes(StandardCharsets.US_ASCII));
-
-        headerAndClaimsBytes = encodedHeaderAndClaims.getBytes(StandardCharsets.US_ASCII);
-
-        //noinspection TryWithIdenticalCatches
         try {
             final Signature signature = Signature.getInstance(ApnsKey.APNS_SIGNATURE_ALGORITHM);
             signature.initVerify(verificationKey);

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/auth/AuthenticationTokenTest.java
@@ -159,14 +159,14 @@ public class AuthenticationTokenTest {
     }
 
     @Test
-    void testAuthenticationTokenFromString() throws Exception {
+    void testAuthenticationTokenFromString() {
         final String base64EncodedToken = new AuthenticationToken(this.signingKey, Instant.now()).toString();
 
         assertDoesNotThrow(() -> new AuthenticationToken(base64EncodedToken));
     }
 
     @Test
-    void testGetIssuedAt() throws Exception {
+    void testGetIssuedAt() {
         final Instant now = Instant.now();
         final AuthenticationToken token = new AuthenticationToken(this.signingKey, now);
 
@@ -206,19 +206,9 @@ public class AuthenticationTokenTest {
     }
 
     @Test
-    void testToString() throws Exception {
+    void testToString() {
         final AuthenticationToken token = new AuthenticationToken(this.signingKey, Instant.now());
 
         assertTrue(Pattern.matches("^[a-zA-Z0-9_\\-]+\\.[a-zA-Z0-9_\\-]+\\.[a-zA-Z0-9_\\-]+$", token.toString()));
-    }
-
-    @Test
-    void testEncodeDecodeBase64() {
-        final byte[] originalBytes =
-                "We expect to get these bytes back after encoding, then decoding as Base64.".getBytes();
-
-        final String encodedString = AuthenticationToken.encodeUnpaddedBase64UrlString(originalBytes);
-
-        assertArrayEquals(originalBytes, AuthenticationToken.decodeBase64UrlEncodedString(encodedString));
     }
 }


### PR DESCRIPTION
This pull request does two things:

1. It remedies potential signature verification errors (described in #1037) in `AuthenticationToken` and
2. It moves away from Netty's more complicated Base64 codec to the much more compact JDK Base64 codec