### PR TITLE
0.15.2 live activities changes

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -134,7 +134,7 @@ public abstract class ApnsPayloadBuilder {
      *
      * @see ApnsPayloadBuilder#setSoundFileName(String)
      */
-    public static final String DEFAULT_SOUND_FILENAME = "default"; 
+    public static final String DEFAULT_SOUND_FILENAME = "default";
 
     /**
     /**
@@ -664,8 +664,8 @@ public abstract class ApnsPayloadBuilder {
      *
      * @return a reference to this payload builder
      *
-     * @see <a href="https://developer.apple.com/documentation/activitykit/update-and-end-your-live-activity-with-remote-push-notifications">
-     *      Updating and ending your Live Activity with remote push notifications</a>
+     * @see <a href="https://developer.apple.com/documentation/activitykit/updating-live-activities-with-activitykit-push-notifications#Mark-a-Live-Activity-as-outdated-by-setting-a-stale-date">
+     *      Mark a Live Activity as outdated by setting a stale date</a>
      */
     public ApnsPayloadBuilder setStaleDate(final Instant staleDate) {
         this.staleDate = staleDate;

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -134,7 +134,7 @@ public abstract class ApnsPayloadBuilder {
      *
      * @see ApnsPayloadBuilder#setSoundFileName(String)
      */
-    public static final String DEFAULT_SOUND_FILENAME = "default";
+    public static final String DEFAULT_SOUND_FILENAME = "default"; 
 
     /**
     /**

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -508,7 +508,7 @@ public abstract class ApnsPayloadBuilderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {-7, 1.1, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY})
+    @ValueSource(doubles = {Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY})
     void testSetRelevanceScoreIllegalValue(final double illegalRelevanceScore) {
         assertThrows(IllegalArgumentException.class, () -> this.builder.setRelevanceScore(illegalRelevanceScore));
     }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -646,6 +646,16 @@ public abstract class ApnsPayloadBuilderTest {
         assertEquals(dismissalDate.getEpochSecond(), aps.get("dismissal-date"));
     }
 
+    @Test
+    void setStaleDate() {
+        final Instant staleDate = Instant.now();
+        this.builder.setStaleDate(staleDate);
+
+        final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+
+        assertEquals(staleDate.getEpochSecond(), aps.get("stale-date"));
+    }
+
     @ParameterizedTest
     @EnumSource(LiveActivityEvent.class)
     void setEvent(LiveActivityEvent event) {

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -508,7 +508,7 @@ public abstract class ApnsPayloadBuilderTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY})
+    @ValueSource(doubles = {Double.NaN})
     void testSetRelevanceScoreIllegalValue(final double illegalRelevanceScore) {
         assertThrows(IllegalArgumentException.class, () -> this.builder.setRelevanceScore(illegalRelevanceScore));
     }


### PR DESCRIPTION
- Allow any number when setting relevance score
- Set stale-date on the aps payload for live activities

This fixes #1033.