### PR TITLE
Support apns unique id

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -360,23 +360,20 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     }
 
     private static UUID getApnsIdFromHeaders(final Http2Headers headers) {
-        final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
-
-        try {
-            return apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
-        } catch (final IllegalArgumentException e) {
-            log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
-            return null;
-        }
+        return getUUIDFromHeaders(headers, APNS_ID_HEADER);
     }
 
     private static UUID getApnsUniqueIdFromHeaders(final Http2Headers headers) {
-        final CharSequence apnsIdSequence = headers.get(APNS_UNIQUE_ID_HEADER);
+        return getUUIDFromHeaders(headers, APNS_UNIQUE_ID_HEADER);
+    }
+
+    private static UUID getUUIDFromHeaders(final Http2Headers headers, final AsciiString header) {
+        final CharSequence apnsIdSequence = headers.get(header);
 
         try {
             return apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
         } catch (final IllegalArgumentException e) {
-            log.error("Failed to parse `{}` header: {}", APNS_UNIQUE_ID_HEADER, apnsIdSequence, e);
+            log.error("Failed to parse `{}` header: {}", header, apnsIdSequence, e);
             return null;
         }
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -76,6 +76,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
+    private static final AsciiString APNS_UNIQUE_ID_HEADER = new AsciiString("apns-unique-id");
     private static final AsciiString APNS_PUSH_TYPE_HEADER = new AsciiString("apns-push-type");
 
     private static final IOException STREAMS_EXHAUSTED_EXCEPTION =
@@ -325,7 +326,8 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         if (HttpResponseStatus.OK.equals(status)) {
             responseFuture.complete(new SimplePushNotificationResponse<>(responseFuture.getPushNotification(),
-                    true, getApnsIdFromHeaders(headers), status.code(), null, null));
+                    true, getApnsIdFromHeaders(headers), getApnsUniqueIdFromHeaders(headers),
+                    status.code(), null, null));
         } else {
             if (data != null) {
                 ErrorResponse errorResponse;
@@ -352,7 +354,8 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         final HttpResponseStatus status = HttpResponseStatus.parseLine(headers.status());
 
         responseFuture.complete(new SimplePushNotificationResponse<>(responseFuture.getPushNotification(),
-                HttpResponseStatus.OK.equals(status), getApnsIdFromHeaders(headers), status.code(),
+                HttpResponseStatus.OK.equals(status), getApnsIdFromHeaders(headers),
+                getApnsUniqueIdFromHeaders(headers), status.code(),
                 errorResponse.getReason(), errorResponse.getTimestamp()));
     }
 
@@ -363,6 +366,17 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
             return apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
         } catch (final IllegalArgumentException e) {
             log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
+            return null;
+        }
+    }
+
+    private static UUID getApnsUniqueIdFromHeaders(final Http2Headers headers) {
+        final CharSequence apnsIdSequence = headers.get(APNS_UNIQUE_ID_HEADER);
+
+        try {
+            return apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
+        } catch (final IllegalArgumentException e) {
+            log.error("Failed to parse `{}` header: {}", APNS_UNIQUE_ID_HEADER, apnsIdSequence, e);
             return null;
         }
     }

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/PushNotificationResponse.java
@@ -62,6 +62,16 @@ public interface PushNotificationResponse<T extends ApnsPushNotification> {
      */
     UUID getApnsId();
 
+
+    /**
+     * Returns a unique ID only available in the development environment.
+     * Useful to query push information in Push Notifications Console.
+     * @return UUID The apns unique id
+     */
+    default Optional<UUID> getApnsUniqueId() {
+        return Optional.empty();
+    }
+
     /**
      * Returns the HTTP status code reported by the APNs server.
      *

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
@@ -37,14 +37,16 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     private final T pushNotification;
     private final boolean success;
     private final UUID apnsId;
+    private final UUID apnsUniqueId;
     private final int statusCode;
     private final String rejectionReason;
     private final Instant tokenExpirationTimestamp;
 
-    SimplePushNotificationResponse(final T pushNotification, final boolean success, final UUID apnsId, final int statusCode, final String rejectionReason, final Instant tokenExpirationTimestamp) {
+    SimplePushNotificationResponse(final T pushNotification, final boolean success, final UUID apnsId, final UUID apnsUniqueId, final int statusCode, final String rejectionReason, final Instant tokenExpirationTimestamp) {
         this.pushNotification = pushNotification;
         this.success = success;
         this.apnsId = apnsId;
+        this.apnsUniqueId = apnsUniqueId;
         this.statusCode = statusCode;
         this.rejectionReason = rejectionReason;
         this.tokenExpirationTimestamp = tokenExpirationTimestamp;
@@ -63,6 +65,11 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     @Override
     public UUID getApnsId() {
         return this.apnsId;
+    }
+
+    @Override
+    public Optional<UUID> getApnsUniqueId() {
+        return Optional.ofNullable(apnsUniqueId);
     }
 
     @Override
@@ -86,6 +93,7 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
                 "pushNotification=" + pushNotification +
                 ", success=" + success +
                 ", apnsId=" + (apnsId != null ? FastUUID.toString(apnsId) : null) +
+                ", apnsUniqueId=" + getApnsUniqueId().map(FastUUID::toString).orElse(null) +
                 ", rejectionReason='" + rejectionReason + '\'' +
                 ", tokenExpirationTimestamp=" + tokenExpirationTimestamp +
                 '}';

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServer.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServer.java
@@ -53,10 +53,11 @@ public class MockApnsServer extends BaseHttp2Server {
     private final MockApnsServerListener listener;
 
     private final int maxConcurrentStreams;
+    private final boolean generateApnsUniqueId;
 
     MockApnsServer(final SslContext sslContext, final EventLoopGroup eventLoopGroup,
                    final PushNotificationHandlerFactory handlerFactory, final MockApnsServerListener listener,
-                   final int maxConcurrentStreams) {
+                   final int maxConcurrentStreams, boolean generateApnsUniqueId) {
 
         super(sslContext, eventLoopGroup);
 
@@ -64,6 +65,7 @@ public class MockApnsServer extends BaseHttp2Server {
         this.listener = listener;
 
         this.maxConcurrentStreams = maxConcurrentStreams;
+        this.generateApnsUniqueId = generateApnsUniqueId;
     }
 
     @Override
@@ -74,6 +76,7 @@ public class MockApnsServer extends BaseHttp2Server {
                 .pushNotificationHandler(pushNotificationHandler)
                 .initialSettings(Http2Settings.defaultSettings().maxConcurrentStreams(this.maxConcurrentStreams))
                 .listener(this.listener)
+                .generateApnsUniqueId(generateApnsUniqueId)
                 .build();
 
         pipeline.addLast(serverHandler);

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerBuilder.java
@@ -48,6 +48,7 @@ public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer
 
     private PushNotificationHandlerFactory handlerFactory;
     private MockApnsServerListener listener;
+    private boolean generateApnsUniqueId = false;
 
     @Override
     public MockApnsServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
@@ -133,6 +134,11 @@ public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer
         return this;
     }
 
+    public MockApnsServerBuilder generateApnsUniqueId(boolean generateApnsUniqueId) {
+        this.generateApnsUniqueId = generateApnsUniqueId;
+        return this;
+    }
+
     @Override
     public MockApnsServer build() throws SSLException {
         return super.build();
@@ -144,6 +150,6 @@ public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer
             throw new IllegalStateException("Must provide a push notification handler factory before building a mock server.");
         }
 
-        return new MockApnsServer(sslContext, this.eventLoopGroup, this.handlerFactory, this.listener, this.maxConcurrentStreams);
+        return new MockApnsServer(sslContext, this.eventLoopGroup, this.handlerFactory, this.listener, this.maxConcurrentStreams, generateApnsUniqueId);
     }
 }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -25,10 +25,7 @@ package com.eatthepath.pushy.apns;
 import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
 import com.eatthepath.pushy.apns.auth.ApnsVerificationKey;
 import com.eatthepath.pushy.apns.auth.KeyPairUtil;
-import com.eatthepath.pushy.apns.server.MockApnsServer;
-import com.eatthepath.pushy.apns.server.MockApnsServerBuilder;
-import com.eatthepath.pushy.apns.server.MockApnsServerListener;
-import com.eatthepath.pushy.apns.server.PushNotificationHandlerFactory;
+import com.eatthepath.pushy.apns.server.*;
 import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -144,13 +141,22 @@ public class AbstractClientServerTest {
         return this.buildServer(handlerFactory, null);
     }
 
+    protected MockApnsServer buildServer(final ValidatingPushNotificationHandlerFactory handlerFactory, final boolean generateApnsUniqueId) throws SSLException {
+        return this.buildServer(handlerFactory, null, generateApnsUniqueId);
+    }
+
     protected MockApnsServer buildServer(final PushNotificationHandlerFactory handlerFactory, final MockApnsServerListener listener) throws SSLException {
+        return this.buildServer(handlerFactory, listener, false);
+    }
+
+    protected MockApnsServer buildServer(final PushNotificationHandlerFactory handlerFactory, final MockApnsServerListener listener, final boolean generateApnsUniqueId) throws SSLException {
         return new MockApnsServerBuilder()
                 .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                 .setTrustedClientCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(SERVER_EVENT_LOOP_GROUP)
                 .setHandlerFactory(handlerFactory)
                 .setListener(listener)
+                .generateApnsUniqueId(generateApnsUniqueId)
                 .build();
     }
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -23,6 +23,7 @@
 package com.eatthepath.pushy.apns.server;
 
 import com.eatthepath.pushy.apns.DeliveryPriority;
+import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.codec.http.HttpMethod;
@@ -35,10 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,6 +51,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
     private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
+    private static final AsciiString APNS_UNIQUE_ID_HEADER = new AsciiString("apns-unique-id");
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
 
     protected static final Map<String, Set<String>> DEVICE_TOKENS_BY_TOPIC =
@@ -106,6 +105,22 @@ public abstract class ValidatingPushNotificationHandlerTest {
     @Test
     void testHandleNotificationWithCollapseId() throws Exception {
         this.headers.set(APNS_COLLAPSE_ID_HEADER, "Collapse ID!");
+
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
+                .handlePushNotification(this.headers, this.payload);
+    }
+
+    @Test
+    void testHandleNotificationWithApnsUniqueId() throws Exception {
+        this.headers.set(APNS_UNIQUE_ID_HEADER, UUID.randomUUID().toString());
+
+        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
+                .handlePushNotification(this.headers, this.payload);
+    }
+
+    @Test
+    void testHandleNotificationWithAnInvalidApnsUniqueId() throws Exception {
+        this.headers.set(APNS_UNIQUE_ID_HEADER, "It's no a valid UUID");
 
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);


### PR DESCRIPTION
Read 'apns-unique-id' from response headers. Closes https://github.com/jchambers/pushy/issues/1028