### PR TITLE
Significantly overhaul the `ApnsClientMetricsListener` interface

### DIFF
--- a/micrometer-metrics-listener/README.md
+++ b/micrometer-metrics-listener/README.md
@@ -18,8 +18,7 @@ Creating new Micrometer listeners is straightforward. To get started, construct 
 
 ```java
 final MicrometerApnsClientMetricsListener listener =
-        new MicrometerApnsClientMetricsListener(existingMeterRegistry,
-                "notifications", "apns", "pushy");
+        new MicrometerApnsClientMetricsListener(existingMeterRegistry);
 
 final ApnsClient apnsClient = new ApnsClientBuilder()
         .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
@@ -29,7 +28,7 @@ final ApnsClient apnsClient = new ApnsClientBuilder()
         .build();
 ```
 
-Note that a `MicrometerApnsClientMetricsListener` is intended for use with only one `ApnsClient` at a time; if you're constructing multiple clients with the same builder, you'll need to specify a new listener for each client.
+Note that a `MicrometerApnsClientMetricsListener` is intended for use with only one `ApnsClient` at a time; if you're constructing multiple clients with the same builder, you'll need to specify a new listener for each client and should consider supplying identifying tags to each listener.
 
 ## License
 

--- a/micrometer-metrics-listener/src/test/java/com/eatthepath/pushy/apns/metrics/micrometer/ExampleApp.java
+++ b/micrometer-metrics-listener/src/test/java/com/eatthepath/pushy/apns/metrics/micrometer/ExampleApp.java
@@ -40,8 +40,7 @@ public class ExampleApp {
         // clients with the same builder, you'll need to specify a new listener
         // for each client.
         final MicrometerApnsClientMetricsListener listener =
-                new MicrometerApnsClientMetricsListener(existingMeterRegistry,
-                        "notifications", "apns", "pushy");
+                new MicrometerApnsClientMetricsListener(existingMeterRegistry);
 
         final ApnsClient apnsClient = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientMetricsListener.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientMetricsListener.java
@@ -42,79 +42,60 @@ package com.eatthepath.pushy.apns;
 public interface ApnsClientMetricsListener {
 
     /**
-     * Indicates that an attempt to send a push notification failed before the notification was processed by the APNs
-     * server. Write failures may be the first event in a sequence for a given notification ID (indicating that the
+     * Indicates that an attempt to send a push notification failed before the notification was acknowledged by the APNs
+     * server. Write failures may be the first event in a sequence for a given notification (indicating that the
      * notification was never written to the wire), but may also occur after a notification was sent if the connection
      * closed before the notification was acknowledged by the server.
      *
-     * @param apnsClient the client that sent the notification
-     * @param notificationId an opaque identifier for the push notification that can be used to correlate this event
-     * with other events related to the same notification
+     * @param topic the APNs topic to which the notification was sent
      *
-     * @since 0.6
+     * @since 0.16
      */
-    void handleWriteFailure(ApnsClient apnsClient, long notificationId);
+    void handleWriteFailure(String topic);
 
     /**
      * Indicates that a notification was sent to the APNs server. Note that a sent notification may still be either
      * accepted or rejected by the APNs server later; sending the notification doesn't imply anything about the ultimate
      * state of the notification.
      *
-     * @param apnsClient the client that sent the notification
-     * @param notificationId an opaque identifier for the push notification that can be used to correlate this event
-     * with other events related to the same notification
+     * @param topic the APNs topic to which the notification was sent
      *
-     * @since 0.6
+     * @since 0.16
      */
-    void handleNotificationSent(ApnsClient apnsClient, long notificationId);
+    void handleNotificationSent(String topic);
 
     /**
-     * Indicates that a notification that was previously sent to an APNs server was accepted by the server.
+     * Indicates that a notification that was previously sent to an APNs server was acknowledged (i.e. either accepted
+     * or rejected) by the server.
      *
-     * @param apnsClient the client that sent the notification
-     * @param notificationId an opaque identifier for the push notification that can be used to correlate this event
-     * with other events related to the same notification
+     * @param response the response from the server
+     * @param durationNanos the duration, measured in nanoseconds, between the time when
+     * {@link ApnsClient#sendNotification(ApnsPushNotification)} was called for the notification in question and when
+     * the server acknowledged the notification
      *
-     * @since 0.6
+     * @since 0.16
      */
-    void handleNotificationAccepted(ApnsClient apnsClient, long notificationId);
-
-    /**
-     * Indicates that a notification that was previously sent to an APNs server was rejected by the server.
-     *
-     * @param apnsClient the client that sent the notification
-     * @param notificationId an opaque identifier for the push notification that can be used to correlate this event
-     * with other events related to the same notification
-     *
-     * @since 0.6
-     */
-    void handleNotificationRejected(ApnsClient apnsClient, long notificationId);
+    void handleNotificationAcknowledged(PushNotificationResponse<?> response, long durationNanos);
 
     /**
      * Indicates that the client has successfully created a new connection to the APNs server in its internal
      * connection pool.
      *
-     * @param apnsClient the client that created the new connection
-     *
      * @since 0.11
      */
-    void handleConnectionAdded(ApnsClient apnsClient);
+    void handleConnectionAdded();
 
     /**
      * Indicates that the client has removed a previously-added connection from its internal connection pool.
      *
-     * @param apnsClient the client that removed the connection
-     *
      * @since 0.11
      */
-    void handleConnectionRemoved(ApnsClient apnsClient);
+    void handleConnectionRemoved();
 
     /**
      * Indicates that an attempt to create a new connection to the APNs server failed.
      *
-     * @param apnsClient the client that attempted to create a new connection
-     *
      * @since 0.11
      */
-    void handleConnectionCreationFailed(ApnsClient apnsClient);
+    void handleConnectionCreationFailed();
 }


### PR DESCRIPTION
This (in my opinion) greatly improves the `ApnsClientMetricsListener` interface at the cost of making a bunch of breaking changes. The key changes are:

1. We no longer issue opaque "notification IDs" to metrics listeners, but instead provide "send notification" durations where appropriate
2. We now consolidate accepted/rejected handlers into a single "acknowledged" handler that has access to the full notification response
3. The Micrometer implementation is now much, much more sensibly constructed; when I first built it, I had never really used Micrometer before and was mostly guessing at how it worked. Now that I have significant direct experience with it, I can offer a much more sensible and ergonomic design.

Feedback on all of this is very welcome.