### PR TITLE
Add a "start" event for Live Activities

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/LiveActivityEvent.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/LiveActivityEvent.java
@@ -25,11 +25,16 @@ package com.eatthepath.pushy.apns.util;
 /**
  * An enumeration of accepted actions for Live Activity notification payloads.
  *
- * @see <a href="https://developer.apple.com/documentation/activitykit/update-and-end-your-live-activity-with-remote-push-notifications">Updating and ending your Live Activity with remote push notifications</a>
+ * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity">Starting and updating Live Activities with ActivityKit push notifications</a>
  *
  * @since 0.15.2
 */
 public enum LiveActivityEvent {
+    /**
+     * Used to start a Live Activity.
+     */
+    START("start"),
+
     /**
      * Used to update a Live Activity.
      */


### PR DESCRIPTION
Evidently, the process for starting Live Activities has changed in the latest iOS release. The old documentation (https://developer.apple.com/documentation/activitykit/update-and-end-your-live-activity-with-remote-push-notifications) appears to have been replaced with https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications, which now calls for explicit "start" events and makes no mention of "end" events.

It's unclear to me if this change is a replacement for the old behavior, an optional replacement, or a mandatory replacement. In any case, I think the safest thing to do is simply to add the new "start" event.

This fixes #1047.