### PR TITLE
Update build matrix for macos/arm64 and node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java }}
     - name: Cache local Maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-22.04, macos-13, macos-latest]
         java: [8, 17, 21]
         transport: [native, JDK]
         tls: [native, JDK]
+        # The macos-14 (and presumably newer) runners are using arm64, and Temurin doesn't support Java 8 on arm64
+        exclude:
+          - os: macos-latest
+            java: 8
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.transport }} transport, ${{ matrix.tls }} SSL provider
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,14 @@ jobs:
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.transport }} transport, ${{ matrix.tls }} SSL provider
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: temurin
         java-version: ${{ matrix.java }}
     - name: Cache local Maven repository
-      uses: actions/cache@v4
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Recently, we've bumped into one warning and one error when building/testing with GitHub Actions:

- Node 16-based actions are now deprecated and should be updated
- The `macos-latest` runner is now `macos-14`, which is arm64 (as opposed to amd64), and Temurin doesn't support Java 8 on arm64

This update addresses both issues.

TODO:

- [x] Pin action versions to specific commit hashes