### PR TITLE
Bump Netty to 4.1.108.Final due to CVE-2024-29025

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/jchambers/pushy/releases/download/pushy-0.15.4/pushy-0.15.4.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.104](http://netty.io/)
+- [netty 4.1.111](http://netty.io/)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.104.Final</netty.version>
+        <netty.version>4.1.108.Final</netty.version>
         <junit.version>5.6.0</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.111.Final</netty.version>
         <junit.version>5.6.0</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is a simple PR that bumps Netty to `4.1.108.Final`. Unit tests seem to run without any issues.

**Background:**

One of my projects uses Pushy and I'm required to compose an SBOM of all dependencies when shipping builds. CVE-2024-29025 was reported due to Pushy's dependency on Netty. 

Vulnerability reported in 0.15.4:

```
NAME              INSTALLED      FIXED-IN       TYPE          VULNERABILITY        SEVERITY 
netty-codec-http  4.1.104.Final  4.1.108.Final  java-archive  GHSA-5jpm-x58v-624v  Medium
```

See https://github.com/advisories/GHSA-5jpm-x58v-624v
