### PR TITLE
Introduce `ApnsClientResources`

### DIFF
--- a/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/eatthepath/pushy/apns/ApnsClientBenchmark.java
@@ -44,7 +44,7 @@ import java.util.concurrent.CountDownLatch;
 @State(Scope.Thread)
 public class ApnsClientBenchmark {
 
-    private NioEventLoopGroup clientEventLoopGroup;
+    private ApnsClientResources clientResources;
     private NioEventLoopGroup serverEventLoopGroup;
 
     private ApnsClient client;
@@ -75,7 +75,7 @@ public class ApnsClientBenchmark {
 
     @Setup
     public void setUp() throws Exception {
-        this.clientEventLoopGroup = new NioEventLoopGroup(this.concurrentConnections);
+        this.clientResources = new ApnsClientResources(new NioEventLoopGroup(this.concurrentConnections));
         this.serverEventLoopGroup = new NioEventLoopGroup(this.concurrentConnections);
 
         final ApnsSigningKey signingKey;
@@ -91,7 +91,7 @@ public class ApnsClientBenchmark {
                 .setConcurrentConnections(this.concurrentConnections)
                 .setSigningKey(signingKey)
                 .setTrustedServerCertificateChain(ApnsClientBenchmark.class.getResourceAsStream(CA_CERTIFICATE_FILENAME))
-                .setEventLoopGroup(this.clientEventLoopGroup)
+                .setApnsClientResources(this.clientResources)
                 .build();
 
         this.server = new BenchmarkApnsServerBuilder()
@@ -136,7 +136,7 @@ public class ApnsClientBenchmark {
         this.client.close().get();
         this.server.shutdown().get();
 
-        final Future<?> clientShutdownFuture = this.clientEventLoopGroup.shutdownGracefully();
+        final Future<?> clientShutdownFuture = this.clientResources.shutdownGracefully();
         final Future<?> serverShutdownFuture = this.serverEventLoopGroup.shutdownGracefully();
 
         clientShutdownFuture.await();

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java
@@ -24,7 +24,6 @@ package com.eatthepath.pushy.apns;
 
 import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
 import com.eatthepath.pushy.apns.proxy.ProxyHandlerFactory;
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.*;
@@ -70,7 +69,7 @@ public class ApnsClientBuilder {
 
     private boolean enableHostnameVerification = true;
 
-    private EventLoopGroup eventLoopGroup;
+    private ApnsClientResources apnsClientResources;
 
     private int concurrentConnections = 1;
 
@@ -390,24 +389,30 @@ public class ApnsClientBuilder {
     }
 
     /**
-     * <p>Sets the event loop group to be used by the client under construction. If not set (or if {@code null}), the
-     * client will create and manage its own event loop group.</p>
+     * <p>Sets the client resources to be used by the client under construction. If not set (or if {@code null}), the
+     * client will manage its own resources.</p>
      *
-     * <p>Generally speaking, callers don't need to set event loop groups for clients, but it may be useful to specify
-     * an event loop group under certain circumstances. In particular, specifying an event loop group that is shared
-     * among multiple {@code ApnsClient} instances can keep thread counts manageable. Regardless of the number of
-     * concurrent {@code ApnsClient} instances, callers may also wish to specify an event loop group to take advantage
-     * of certain platform-specific optimizations (e.g. {@code epoll} or {@code KQueue} event loop groups).</p>
+     * <p>Callers generally don't need to specify resources groups for clients if they only expect to have a single
+     * {@code ApnsClient} instance, but may benefit from specifying a shared set of {@code ApnsClientResources} if they
+     * expect to have multiple concurrent clients. Specifying an event loop group that is shared among multiple
+     * {@code ApnsClient} instances can keep thread counts in check because each client will not need to create its own
+     * thread pool. Regardless of the number of concurrent {@code ApnsClient} instances, callers may also wish to
+     * specify an event loop group to take advantage of certain platform-specific optimizations (e.g. {@code epoll} or
+     * {@code KQueue} event loop groups).</p>
      *
-     * @param eventLoopGroup the event loop group to use for this client, or {@code null} to let the client manage its
-     * own event loop group
+     * <p>Callers that expect to have multiple concurrent {@code ApnsClient} instances will also benefit from sharing an
+     * {@code ApnsClientResources} instance between clients because resource sets contain a shared DNS resolver,
+     * eliminating the need for each client to manage its own DNS connections.</p>
+     *
+     * @param apnsClientResources the client resources to use for this client, or {@code null} to let the client manage
+     * its own resources
      *
      * @return a reference to this builder
      *
-     * @since 0.8
+     * @since 0.16
      */
-    public ApnsClientBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
-        this.eventLoopGroup = eventLoopGroup;
+    public ApnsClientBuilder setApnsClientResources(final ApnsClientResources apnsClientResources) {
+        this.apnsClientResources = apnsClientResources;
         return this;
     }
 
@@ -634,7 +639,7 @@ public class ApnsClientBuilder {
                             this.metricsListener,
                             this.frameLogger);
 
-            return new ApnsClient(clientConfiguration, this.eventLoopGroup);
+            return new ApnsClient(clientConfiguration, this.apnsClientResources);
         } finally {
             if (sslContext instanceof ReferenceCounted) {
                 ((ReferenceCounted) sslContext).release();

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientResources.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientResources.java
@@ -1,0 +1,70 @@
+package com.eatthepath.pushy.apns;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
+import io.netty.resolver.dns.RoundRobinDnsAddressResolverGroup;
+import io.netty.util.concurrent.Future;
+
+import java.util.Objects;
+
+/**
+ * APNs client resources are bundles of relatively "expensive" objects (thread pools, DNS resolvers, etc.) that can be
+ * shared between {@link ApnsClient} instances.
+ *
+ * @see ApnsClientBuilder#setApnsClientResources(ApnsClientResources)
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.16
+ */
+public class ApnsClientResources {
+
+  private final EventLoopGroup eventLoopGroup;
+  private final RoundRobinDnsAddressResolverGroup roundRobinDnsAddressResolverGroup;
+
+  /**
+   * Constructs a new set of client resources that uses the given default event loop group. Clients that use this
+   * resource set will use the given event loop group for IO operations.
+   *
+   * @param eventLoopGroup the event loop group for this set of resources
+   */
+  public ApnsClientResources(final EventLoopGroup eventLoopGroup) {
+    this.eventLoopGroup = Objects.requireNonNull(eventLoopGroup);
+
+    this.roundRobinDnsAddressResolverGroup = new RoundRobinDnsAddressResolverGroup(
+        ClientChannelClassUtil.getDatagramChannelClass(eventLoopGroup),
+        DefaultDnsServerAddressStreamProvider.INSTANCE);
+  }
+
+  /**
+   * Returns the event loop group for this resource set.
+   *
+   * @return the event loop group for this resource set
+   */
+  public EventLoopGroup getEventLoopGroup() {
+    return eventLoopGroup;
+  }
+
+  /**
+   * Returns the DNS resolver for this resource set.
+   *
+   * @return the DNS resolver for this resource set
+   */
+  public RoundRobinDnsAddressResolverGroup getRoundRobinDnsAddressResolverGroup() {
+    return roundRobinDnsAddressResolverGroup;
+  }
+
+  /**
+   * Gracefully shuts down any long-lived resources in this resource group. If callers manage their own
+   * {@code ApnsClientResources} instances (as opposed to using default resources provided by {@link ApnsClientBuilder},
+   * then they <em>must</em> call this method after all clients that use a given set of resources have been shut down.
+   *
+   * @return a future that completes once the long-lived resources in this set of resources has finished shutting down
+   *
+   * @see ApnsClientBuilder#setApnsClientResources(ApnsClientResources)
+   */
+  public Future<?> shutdownGracefully() {
+    roundRobinDnsAddressResolverGroup.close();
+    return eventLoopGroup.shutdownGracefully();
+  }
+}

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/AbstractClientServerTest.java
@@ -47,7 +47,7 @@ import java.util.*;
 @Timeout(10)
 public class AbstractClientServerTest {
 
-    protected static NioEventLoopGroup CLIENT_EVENT_LOOP_GROUP;
+    protected static ApnsClientResources CLIENT_RESOURCES;
     protected static NioEventLoopGroup SERVER_EVENT_LOOP_GROUP;
 
     protected static final String CA_CERTIFICATE_FILENAME = "/ca.pem";
@@ -81,7 +81,7 @@ public class AbstractClientServerTest {
 
     @BeforeAll
     public static void setUpBeforeClass() {
-        CLIENT_EVENT_LOOP_GROUP = new NioEventLoopGroup(2);
+        CLIENT_RESOURCES = new ApnsClientResources(new NioEventLoopGroup(2));
         SERVER_EVENT_LOOP_GROUP = new NioEventLoopGroup(2);
     }
 
@@ -100,7 +100,7 @@ public class AbstractClientServerTest {
     @AfterAll
     public static void tearDownAfterClass() throws Exception {
         final PromiseCombiner combiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE);
-        combiner.addAll(CLIENT_EVENT_LOOP_GROUP.shutdownGracefully(), SERVER_EVENT_LOOP_GROUP.shutdownGracefully());
+        combiner.addAll(CLIENT_RESOURCES.shutdownGracefully(), SERVER_EVENT_LOOP_GROUP.shutdownGracefully());
 
         final Promise<Void> shutdownPromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
         combiner.finish(shutdownPromise);
@@ -117,7 +117,7 @@ public class AbstractClientServerTest {
                     .setApnsServer(HOST, PORT)
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
-                    .setEventLoopGroup(CLIENT_EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .setMetricsListener(metricsListener)
                     .build();
         }
@@ -132,7 +132,7 @@ public class AbstractClientServerTest {
                 .setApnsServer(HOST, PORT)
                 .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setSigningKey(this.signingKey)
-                .setEventLoopGroup(CLIENT_EVENT_LOOP_GROUP)
+                .setApnsClientResources(CLIENT_RESOURCES)
                 .setMetricsListener(metricsListener)
                 .build();
     }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientBuilderTest.java
@@ -44,16 +44,16 @@ public class ApnsClientBuilderTest {
 
     private static final String KEYSTORE_PASSWORD = "pushy-test";
 
-    private static NioEventLoopGroup EVENT_LOOP_GROUP;
+    private static ApnsClientResources CLIENT_RESOURCES;
 
     @BeforeAll
     public static void setUpBeforeClass() {
-        EVENT_LOOP_GROUP = new NioEventLoopGroup(1);
+        CLIENT_RESOURCES = new ApnsClientResources(new NioEventLoopGroup(1));
     }
 
     @AfterAll
     public static void tearDownAfterClass() throws Exception {
-        EVENT_LOOP_GROUP.shutdownGracefully().await();
+        CLIENT_RESOURCES.shutdownGracefully().await();
     }
 
     @Test
@@ -61,7 +61,7 @@ public class ApnsClientBuilderTest {
         // We're happy here as long as nothing throws an exception
         final ApnsClient client = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                .setApnsClientResources(CLIENT_RESOURCES)
                 .setClientCredentials(new File(this.getClass().getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
                 .build();
 
@@ -74,7 +74,7 @@ public class ApnsClientBuilderTest {
         try (final InputStream p12InputStream = this.getClass().getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .build();
 
@@ -85,7 +85,7 @@ public class ApnsClientBuilderTest {
     @Test
     void testBuildClientWithNullPassword() {
         assertThrows(NullPointerException.class, () -> new ApnsClientBuilder()
-                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                .setApnsClientResources(CLIENT_RESOURCES)
                 .setClientCredentials(new File(this.getClass().getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), null)
                 .build());
     }
@@ -99,7 +99,7 @@ public class ApnsClientBuilderTest {
 
             final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), KEYSTORE_PASSWORD)
                     .build();
 
@@ -117,7 +117,7 @@ public class ApnsClientBuilderTest {
 
             final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
                     .build();
 
@@ -133,7 +133,7 @@ public class ApnsClientBuilderTest {
             // We're happy here as long as nothing explodes
             final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .setSigningKey(signingKey)
                     .build();
 
@@ -145,7 +145,7 @@ public class ApnsClientBuilderTest {
     void testBuildWithoutClientCredentials() {
         assertThrows(IllegalStateException.class, () ->
                 new ApnsClientBuilder()
-                        .setEventLoopGroup(EVENT_LOOP_GROUP)
+                        .setApnsClientResources(CLIENT_RESOURCES)
                         .build());
     }
 
@@ -162,7 +162,7 @@ public class ApnsClientBuilderTest {
 
                 assertThrows(IllegalStateException.class, () ->
                         new ApnsClientBuilder()
-                                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                                .setApnsClientResources(CLIENT_RESOURCES)
                                 .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
                                 .setSigningKey(signingKey)
                                 .build());
@@ -174,7 +174,7 @@ public class ApnsClientBuilderTest {
     void testBuildWithoutApnsServerAddress() {
         assertThrows(IllegalStateException.class, () ->
                 new ApnsClientBuilder()
-                        .setEventLoopGroup(EVENT_LOOP_GROUP)
+                        .setApnsClientResources(CLIENT_RESOURCES)
                         .setClientCredentials(new File(this.getClass().getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
                         .build());
     }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/ApnsClientTest.java
@@ -223,14 +223,14 @@ public class ApnsClientTest extends AbstractClientServerTest {
             cautiousClient = new ApnsClientBuilder()
                     .setApnsServer(HOST, PORT)
                     .setSigningKey(this.signingKey)
-                    .setEventLoopGroup(CLIENT_EVENT_LOOP_GROUP)
+                    .setApnsClientResources(CLIENT_RESOURCES)
                     .build();
         } else {
             try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
                 cautiousClient = new ApnsClientBuilder()
                         .setApnsServer(HOST, PORT)
                         .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                        .setEventLoopGroup(CLIENT_EVENT_LOOP_GROUP)
+                        .setApnsClientResources(CLIENT_RESOURCES)
                         .build();
             }
         }
@@ -312,7 +312,7 @@ public class ApnsClientTest extends AbstractClientServerTest {
                 .setApnsServer(HOST, PORT)
                 .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setSigningKey(this.signingKey)
-                .setEventLoopGroup(CLIENT_EVENT_LOOP_GROUP)
+                .setApnsClientResources(CLIENT_RESOURCES)
                 .setHostnameVerificationEnabled(false)
                 .build();
 


### PR DESCRIPTION
This pull request introduces the notion of `ApnsClientResources`, sets of expensive, long-lived resources that can be shared between clients. This is mostly a drop-in replacement for passing `EventLoopGroup` instances around, but adds extension points for additional long-lived resources. In particular, it provides a mechanism for sharing DNS resolver instances between clients, which fixes #881.