### PR TITLE
Update metrics listeners dependencies/READMEs; update to Dropwizard Metrics 4

### DIFF
--- a/dropwizard-metrics-listener/README.md
+++ b/dropwizard-metrics-listener/README.md
@@ -10,7 +10,7 @@ This module is an implementation of Pushy's [`ApnsClientMetricsListener`](https:
 </dependency>
 ```
 
-If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Dropwizard Metrics listener for Pushy depends on Pushy itself (obviously enough) and version 3.2.6 of the [Dropwizard Metrics library](http://metrics.dropwizard.io/).
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Dropwizard Metrics listener for Pushy depends on Pushy itself (obviously enough) and version 4.2.26 of the [Dropwizard Metrics library](http://metrics.dropwizard.io/).
 
 ## Using the Dropwizard Metrics listener
 

--- a/dropwizard-metrics-listener/README.md
+++ b/dropwizard-metrics-listener/README.md
@@ -6,11 +6,11 @@ This module is an implementation of Pushy's [`ApnsClientMetricsListener`](https:
 <dependency>
     <groupId>com.eatthepath</groupId>
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-    <version>0.15.2</version>
+    <version>0.16.0</version>
 </dependency>
 ```
 
-If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Dropwizard Metrics listener for Pushy depends on Pushy itself (obviously enough) and version 3.1.0 of the [Dropwizard Metrics library](http://metrics.dropwizard.io/).
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Dropwizard Metrics listener for Pushy depends on Pushy itself (obviously enough) and version 3.2.6 of the [Dropwizard Metrics library](http://metrics.dropwizard.io/).
 
 ## Using the Dropwizard Metrics listener
 

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.2.6</version>
+            <version>4.2.26</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/micrometer-metrics-listener/README.md
+++ b/micrometer-metrics-listener/README.md
@@ -6,11 +6,11 @@ This module is an implementation of Pushy's [`ApnsClientMetricsListener`](https:
 <dependency>
     <groupId>com.eatthepath</groupId>
     <artifactId>pushy-micrometer-metrics-listener</artifactId>
-    <version>0.15.2</version>
+    <version>0.16.0</version>
 </dependency>
 ```
 
-If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Micrometer listener for Pushy depends on Pushy itself (obviously enough) and version 1.0 of the [Micrometer application monitoring library](http://micrometer.io/). Please note that while Pushy itself works with Java 7 and newer, **the Micrometer metrics listener requires Java 8 or newer.**
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Micrometer listener for Pushy depends on Pushy itself (obviously enough) and version 1.13.1 of the [Micrometer application monitoring library](http://micrometer.io/).
 
 ## Using the Micrometer Metrics listener
 

--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.0.3</version>
+            <version>1.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This updates the Dropwizard Metrics listener to depend on Dropwizard Metrics 4. Dropwizard Metrics 3 is truly ancient; that nobody complained about this so far makes me really suspicious that nobody is really using this listener, and we might benefit from dropping it entirely some time in the future.