### PR TITLE
Add support for starting a Live Activity with input-push-token on iOS 18

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -859,8 +859,12 @@ public abstract class ApnsPayloadBuilder {
     }
 
     /**
-     * <p>Sets the flag to wake up the app and receive a push token to send updates to the started Live Activity.</p>
-     *
+     * Sets the flag to control whether the OS wakes up the app and delivers a push token to send updates to the
+     * started Live Activity. It is only respected in iOS 18 and later. Older versions provide a new push token
+     * by default.
+
+     * @param inputPushToken Flag to decide whether the app is provided a push token to update the Live Activity
+
      * @return a reference to this payload builder
      *
      * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications">

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -82,6 +82,7 @@ public abstract class ApnsPayloadBuilder {
     private boolean preferStringRepresentationForAlerts = false;
 
     private LiveActivityEvent event = null;
+    private Integer inputPushToken = null;
 
     private Instant timestamp = null;
 
@@ -131,6 +132,7 @@ public abstract class ApnsPayloadBuilder {
     private static final String ATTRIBUTES_TYPE_KEY = "attributes-type";
     private static final String ATTRIBUTES_KEY = "attributes";
     private static final String CONTENT_STATE_KEY = "content-state";
+    private static final String INPUT_PUSH_TOKEN_KEY = "input-push-token";
 
     public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
@@ -769,7 +771,7 @@ public abstract class ApnsPayloadBuilder {
      *
      * @return a reference to this payload builder
      *
-     * @see #setAttributes(Map) 
+     * @see #setAttributes(Map)
      * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity">
      *      Construct the payload that starts a Live Activity</a>
      * @see <a href="https://developer.apple.com/documentation/activitykit/activityattributes">ActivityKit - ActivityAttributes</a>
@@ -789,7 +791,7 @@ public abstract class ApnsPayloadBuilder {
      *
      * @return a reference to this payload builder
      *
-     * @see #setAttributesType(String) 
+     * @see #setAttributesType(String)
      * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity">
      *      Construct the payload that starts a Live Activity</a>
      * @see <a href="https://developer.apple.com/documentation/activitykit/activityattributes/contentstate">ActivityKit - ContentState</a>
@@ -853,6 +855,19 @@ public abstract class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setTimestamp(final Instant timestamp) {
         this.timestamp = timestamp;
+        return this;
+    }
+
+    /**
+     * <p>Sets the flag to wake up the app and receive a push token to send updates to the started Live Activity.</p>
+     *
+     * @return a reference to this payload builder
+     *
+     * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications">
+     *      Starting and updating Live Activities with ActivityKit push notifications</a>
+     */
+    public ApnsPayloadBuilder setInputPushToken() {
+        this.inputPushToken = 1;
         return this;
     }
 
@@ -962,6 +977,10 @@ public abstract class ApnsPayloadBuilder {
 
             if (this.staleDate != null) {
                 aps.put(STALE_DATE_KEY, this.staleDate.getEpochSecond());
+            }
+
+            if (this.inputPushToken != null) {
+                aps.put(INPUT_PUSH_TOKEN_KEY, this.inputPushToken);
             }
 
             final Map<String, Object> alert = new HashMap<>();

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilder.java
@@ -82,7 +82,7 @@ public abstract class ApnsPayloadBuilder {
     private boolean preferStringRepresentationForAlerts = false;
 
     private LiveActivityEvent event = null;
-    private Integer inputPushToken = null;
+    private Boolean inputPushToken = null;
 
     private Instant timestamp = null;
 
@@ -866,8 +866,8 @@ public abstract class ApnsPayloadBuilder {
      * @see <a href="https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications">
      *      Starting and updating Live Activities with ActivityKit push notifications</a>
      */
-    public ApnsPayloadBuilder setInputPushToken() {
-        this.inputPushToken = 1;
+    public ApnsPayloadBuilder setInputPushToken(final boolean inputPushToken) {
+        this.inputPushToken = inputPushToken;
         return this;
     }
 
@@ -980,7 +980,7 @@ public abstract class ApnsPayloadBuilder {
             }
 
             if (this.inputPushToken != null) {
-                aps.put(INPUT_PUSH_TOKEN_KEY, this.inputPushToken);
+                aps.put(INPUT_PUSH_TOKEN_KEY, this.inputPushToken ? 1 : 0);
             }
 
             final Map<String, Object> alert = new HashMap<>();

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -728,7 +728,7 @@ public abstract class ApnsPayloadBuilderTest {
 
     @Test
     void setInputPushToken() {
-        this.builder.setInputPushToken();
+        this.builder.setInputPushToken(true);
 
         final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -726,6 +726,15 @@ public abstract class ApnsPayloadBuilderTest {
         assertEquals(subMap, serializedContentState.get(keyForMapValue));
     }
 
+    @Test
+    void setInputPushToken() {
+        this.builder.setInputPushToken();
+
+        final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.build());
+
+        assertEquals(1L, aps.get("input-push-token"));
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> extractApsObjectFromPayloadString(final String payloadString) {
         final Map<String, Object> payload;


### PR DESCRIPTION
Adds support for passing the `input-push-token` attribute, which is required in iOS 18 to start a Live Activity that wakes the app to get a push token to update the created Live Activity (which was not needed on iOS 17).

This has been tested with iOS 18.0 beta 6. 

Apple docs: https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications